### PR TITLE
Quiz dinamico

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -128,4 +128,42 @@ input:focus, textarea:focus {
     border-color: var(--labels-color);
 }
 
+/* Estilos para o filtro de preço */
+#price-value {
+    color: var(--buttons-color, #D90429);
+}
+
+input[type="range"] {
+    -webkit-appearance: none;
+    width: 100%;
+    height: 0.5rem;
+    background: var(--track-color, #e9ecef);
+    border-radius: 0.25rem;
+    outline: none;
+}
+.form-range {
+    --thumb-color: var(--buttons-color, #D90429);
+    --track-color: #e9ecef;
+}
+
+.form-range::-webkit-slider-thumb {
+    background-color: var(--thumb-color);
+}
+
+.form-range::-moz-range-thumb {
+    background-color: var(--thumb-color);
+}
+
+.form-range:focus {
+    box-shadow: none;
+}
+
+.form-range:focus::-webkit-slider-thumb {
+    box-shadow: 0 0 0 0.25rem rgba(217, 4, 41, 0.25);
+}
+
+.form-range:focus::-moz-range-thumb {
+    box-shadow: 0 0 0 0.25rem rgba(217, 4, 41, 0.25);
+}
+
 /*end of main.css*/

--- a/css/profile.css
+++ b/css/profile.css
@@ -101,3 +101,104 @@
     flex-direction: column;
     gap: 1rem;
 }
+
+.recommended-destinations-list {
+    display: flex;
+    overflow-x: auto;
+    gap: 1.5rem;
+    padding: 1rem 0.5rem;
+    padding-bottom: 1rem; /* Adiciona espaço para a scrollbar */
+    scrollbar-width: thin;  /* Para Firefox */
+    scrollbar-color: var(--buttons-color) #f1f1f1; /* Para Firefox */
+}
+
+.recommended-destinations-list::-webkit-scrollbar {
+    height: 8px; /* Altura da scrollbar */
+}
+
+.recommended-destinations-list::-webkit-scrollbar-track {
+    background: #f1f1f1; /* Cor do fundo da track */
+    border-radius: 10px;
+}
+
+.recommended-destinations-list::-webkit-scrollbar-thumb {
+    background-color: var(--buttons-color); /* Cor do polegar */
+    border-radius: 10px;
+    border: 2px solid #f1f1f1; /* Borda à volta do polegar */
+}
+
+.recommended-destinations-list::-webkit-scrollbar-thumb:hover {
+    background-color: #a7031f; /* Cor do polegar ao passar o rato */
+}
+
+/* Estilo dos cartões de destino, coerente com a secção de destaques */
+.recommended-destinations-list .destination-card {
+    flex: 0 0 280px; /* Define uma largura fixa para os cartões */
+    max-width: 280px;
+}
+
+.recommended-destinations-list .card {
+    border: none;
+    border-radius: 16px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    height: 100%;
+    overflow: hidden;
+    position: relative;
+}
+
+/* Adicione estas regras para garantir o posicionamento e estilo do botão de favorito */
+.recommended-destinations-list .favorite-btn {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    z-index: 10;
+    background-color: rgba(255, 255, 255, 0.9);
+    border: none;
+    border-radius: 50%;
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    color: #adb5bd; /* Cor da estrela inativa */
+    transition: all 0.2s ease-in-out;
+}
+
+.recommended-destinations-list .favorite-btn:hover,
+.recommended-destinations-list .favorite-btn.active {
+    background-color: var(--buttons-color);
+    color: var(--text-color); /* Cor da estrela ativa/hover */
+}
+
+.recommended-destinations-list .card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+}
+
+.recommended-destinations-list .card-img-top {
+    height: 180px;
+    object-fit: cover;
+}
+
+.recommended-destinations-list .card-title {
+    color: var(--bg-color);
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}
+
+.recommended-destinations-list .btn-primary {
+    background-color: var(--buttons-color);
+    border-color: var(--buttons-color);
+    border-radius: 50px;
+    font-weight: 500;
+    padding: 0.6rem 1.5rem;
+    transition: background-color 0.3s ease;
+}
+
+.recommended-destinations-list .btn-primary:hover {
+    background-color: #a7031f;
+    border-color: #a7031f;
+}

--- a/css/quiz.css
+++ b/css/quiz.css
@@ -36,3 +36,77 @@
 .progress-bar {
     transition: width 0.5s ease;
 }
+
+.recommended-destinations-list {
+    display: flex;
+    overflow-x: auto;
+    gap: 1.5rem;
+    padding: 1rem 0.5rem;
+    padding-bottom: 1rem; /* Adiciona espaço para a scrollbar */
+    scrollbar-width: thin;  /* Para Firefox */
+    scrollbar-color: var(--buttons-color) #f1f1f1; /* Para Firefox */
+}
+
+.recommended-destinations-list::-webkit-scrollbar {
+    height: 8px; /* Altura da scrollbar */
+}
+
+.recommended-destinations-list::-webkit-scrollbar-track {
+    background: #f1f1f1; /* Cor do fundo da track */
+    border-radius: 10px;
+}
+
+.recommended-destinations-list::-webkit-scrollbar-thumb {
+    background-color: var(--buttons-color); /* Cor do polegar */
+    border-radius: 10px;
+    border: 2px solid #f1f1f1; /* Borda à volta do polegar */
+}
+
+.recommended-destinations-list::-webkit-scrollbar-thumb:hover {
+    background-color: #a7031f; /* Cor do polegar ao passar o rato */
+}
+
+/* Estilo dos cartões de destino, coerente com a secção de destaques */
+.recommended-destinations-list .destination-card {
+    flex: 0 0 280px; /* Define uma largura fixa para os cartões */
+    max-width: 280px;
+}
+
+.recommended-destinations-list .card {
+    border: none;
+    border-radius: 16px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    height: 100%;
+    overflow: hidden;
+}
+
+.recommended-destinations-list .card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+}
+
+.recommended-destinations-list .card-img-top {
+    height: 180px;
+    object-fit: cover;
+}
+
+.recommended-destinations-list .card-title {
+    color: var(--bg-color);
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}
+
+.recommended-destinations-list .btn-primary {
+    background-color: var(--buttons-color);
+    border-color: var(--buttons-color);
+    border-radius: 50px;
+    font-weight: 500;
+    padding: 0.6rem 1.5rem;
+    transition: background-color 0.3s ease;
+}
+
+.recommended-destinations-list .btn-primary:hover {
+    background-color: #a7031f;
+    border-color: #a7031f;
+}

--- a/css/quiz.css
+++ b/css/quiz.css
@@ -79,6 +79,7 @@
     transition: transform 0.3s ease, box-shadow 0.3s ease;
     height: 100%;
     overflow: hidden;
+    position: relative;
 }
 
 .recommended-destinations-list .card:hover {

--- a/html/admindestinations.html
+++ b/html/admindestinations.html
@@ -101,11 +101,7 @@
                         <div class="mb-3">
                             <label for="TipoTurismo" class="form-label">Tipo de Turismo</label>
                             <select class="form-select" name="TipoTurismo" required>
-                                <option value="">Selecione o tipo</option>
-                                <option value="religioso">Religioso</option>
-                                <option value="arquitetonico">Arquitetónico</option>
-                                <option value="aventura">Aventura</option>
-                                <option value="gastronomico">Gastronómico</option>
+                                <!-- As opções serão preenchidas dinamicamente pelo JavaScript -->
                             </select>
                         </div>
                         <div class="mb-3">
@@ -153,11 +149,7 @@
                         <div class="mb-3">
                             <label class="form-label">Tipo de Turismo</label>
                             <select class="form-select" name="editTipoTurismo" required>
-                                <option value="">Selecione o tipo</option>
-                                <option value="religioso">Religioso</option>
-                                <option value="arquitetonico">Arquitetónico</option>
-                                <option value="aventura">Aventura</option>
-                                <option value="gastronomico">Gastronómico</option>
+                                <!-- As opções serão preenchidas dinamicamente pelo JavaScript -->
                             </select>
                         </div>
                         <div class="mb-3">

--- a/html/profile.html
+++ b/html/profile.html
@@ -75,6 +75,19 @@
                         <button type="button" class="btn btn-secondary cancel-btn">Cancelar</button>
                     </div>
                 </form>
+                <div id="quiz-results-section" class="mt-5" style="display: none;">
+                    <hr>
+                    <h2 class="mt-4">O seu Perfil de Viajante</h2>
+                    <div class="row" id="scores-container">
+                        <!-- Scores do quiz serão carregados aqui -->
+                    </div>
+                    <div class="text-center mt-4">
+                        <p>Com base no seu perfil, estas são as nossas recomendações para si!</p>
+                    </div>
+                    <div id="recommended-destinations-container" class="container mt-3 px-0">
+                        <!-- Carrossel de recomendações será injetado aqui -->
+                    </div>
+                </div>
             </div>
 
             <div id="favorites" class="content-section">

--- a/html/quiz.html
+++ b/html/quiz.html
@@ -32,7 +32,8 @@
 
             <!-- Centered Logo -->
             <a class="navbar-brand mx-auto" href="#"></a>
-            <img src="../img/LogoNavbar.png" alt="Logo" height="40">
+            <a href="/index.html">
+                <img src="../img/LogoNavbar.png" alt="Logo" height="40">
             </a>
 
             <!-- Right User Icon -->
@@ -58,7 +59,7 @@
                         </div>
                     </div>
                     <div id="loggedOutMenu" style="display: none;">
-                        <a class="nav-link nav-icon" href="/html/login.html">
+                        <a class="nav-link nav-icon" href="login.html">
                             <i class="fas fa-user-circle" style="color: #D90429; transition: all 0.3s ease;"></i>
                         </a>
                     </div>

--- a/html/quiz.html
+++ b/html/quiz.html
@@ -105,67 +105,8 @@
                                 <p>Confere as viagens mais adequadas ao que procuras!</p>
                                 <i class="fas fa-arrow-down" style="font-size: 2rem; color: #D90429;"></i>
                             </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <section class="featured-deals" id="Destaques">
-        <div class="container py-5">
-            <h2 class="text-center mb-4">Destinos em Destaque</h2>
-            <div class="row g-4">
-                <!-- Card 1 -->
-                <div class="col-md-4">
-                    <div class="card h-100">
-                        <button class="favorite-btn">
-                            <i class="fas fa-star"></i>
-                        </button>
-                        <img src="https://plus.unsplash.com/premium_photo-1661919210043-fd847a58522d?fm=jpg&q=60&w=3000&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8cGFyaXN8ZW58MHx8MHx8fDA%3D"
-                            class="card-img-top" alt="Paris">
-                        <div class="card-body">
-                            <h5 class="card-title">Paris, França</h5>
-                            <p class="card-text">Voos diretos a partir de €199</p>
-                            <div class="d-flex justify-content-between align-items-center">
-                                <span class="price">€199</span>
-                                <button class="btn btn-primary">Ver Oferta</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Card 2 -->
-                <div class="col-md-4">
-                    <div class="card h-100">
-                        <button class="favorite-btn">
-                            <i class="fas fa-star"></i>
-                        </button>
-                        <img src="https://media.istockphoto.com/id/539115110/pt/foto/colosseum-em-roma-e-manh%C3%A3-de-sol-it%C3%A1lia.jpg?s=612x612&w=0&k=20&c=UJgNdZwEeoznZvOusoUoEtG6or5nweBNJxZbPxmi7dM="
-                            class="card-img-top" alt="Roma">
-                        <div class="card-body">
-                            <h5 class="card-title">Roma, Itália</h5>
-                            <p class="card-text">Pacotes com hotel desde €299</p>
-                            <div class="d-flex justify-content-between align-items-center">
-                                <span class="price">€299</span>
-                                <button class="btn btn-primary">Ver Oferta</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Card 3 -->
-                <div class="col-md-4">
-                    <div class="card h-100">
-                        <button class="favorite-btn">
-                            <i class="fas fa-star"></i>
-                        </button>
-                        <img src="https://mediaim.expedia.com/destination/9/cd8a3f3db7149b0ce36d052aea1182df.jpg"
-                            class="card-img-top" alt="Dubai">
-                        <div class="card-body">
-                            <h5 class="card-title">Dubai</h5>
-                            <p class="card-text">Experiência luxuosa desde €599</p>
-                            <div class="d-flex justify-content-between align-items-center">
-                                <span class="price">€599</span>
-                                <button class="btn btn-primary">Ver Oferta</button>
+                            <div id="recommended-destinations-container" class="container mt-5">
+                                <!-- O conteúdo do carrossel será injetado aqui pelo JavaScript -->
                             </div>
                         </div>
                     </div>
@@ -239,7 +180,6 @@
         integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous">
         </script>
     <script src="../js/views/NavbarView.js" type="module"></script>
-    <script src="../js/models/quiz.js"></script>
+    <script src="../js/models/quiz.js" type="module"></script>
 </body>
-
 </html>

--- a/index.html
+++ b/index.html
@@ -128,6 +128,12 @@
     <section class="featured-deals" id="Destaques">
         <div class="container py-5">
             <h2 class="text-center mb-4">Ofertas de Voos</h2>
+            <div class="row justify-content-center mb-4">
+                <div class="col-md-6">
+                    <label for="price-filter" class="form-label">Preço Máximo: <span id="price-value" class="fw-bold"></span></label>
+                    <input type="range" class="form-range" id="price-filter" min="0" max="2000" step="10">
+                </div>
+            </div>
             <div class="row g-4" id="flightCardsContainer">
                 
                 <!-- <div class="col-md-4">

--- a/js/data/destinations.json
+++ b/js/data/destinations.json
@@ -13,7 +13,7 @@
             "id": 2,
             "Destino": "Rio de Janeiro",
             "Pais": "Brasil",
-            "TipoTurismo": "Praia",
+            "TipoTurismo": "Balnear",
             "Descricao": "Cidade maravilhosa com praias icônicas como Copacabana e Ipanema, além do Cristo Redentor.",
             "ImagemDestino": "rio_de_janeiro.jpg",
             "CodigoDestino": "GIG"
@@ -40,7 +40,7 @@
             "id": 5,
             "Destino": "Cabo Verde",
             "Pais": "Cabo Verde",
-            "TipoTurismo": "Praia",
+            "TipoTurismo": "Balnear",
             "Descricao": "Arquipélago africano conhecido pelas suas praias paradisíacas e cultura vibrante.",
             "ImagemDestino": "cabo_verde.jpg",
             "CodigoDestino": "RAI"
@@ -139,7 +139,7 @@
             "id": 16,
             "Destino": "Maldivas",
             "Pais": "Maldivas",
-            "TipoTurismo": "Praia",
+            "TipoTurismo": "Balnear",
             "Descricao": "Ilhas paradisíacas com águas cristalinas e resorts de luxo.",
             "ImagemDestino": "maldivas.jpg",
             "CodigoDestino": "MLE"
@@ -166,7 +166,7 @@
             "id": 19,
             "Destino": "Santorini",
             "Pais": "Grécia",
-            "TipoTurismo": "Praia",
+            "TipoTurismo": "Balnear",
             "Descricao": "Ilha famosa por suas casas brancas e vistas deslumbrantes do mar Egeu.",
             "ImagemDestino": "santorini.jpg",
             "CodigoDestino": "JTR"

--- a/js/data/destinations.json
+++ b/js/data/destinations.json
@@ -290,11 +290,11 @@
         },
         {
             "id": 33,
-            "Destino": "Vale do Douro",
+            "Destino": "Porto",
             "Pais": "Portugal",
-            "TipoTurismo": "Rural",
-            "Descricao": "Paisagem deslumbrante de vinhas em socalcos ao longo do rio Douro, berço do Vinho do Porto.",
-            "ImagemDestino": "valedodouro.jpg",
+            "TipoTurismo": "Cultural",
+            "Descricao": "Cidade histórica do norte de Portugal, famosa pelo vinho do Porto e arquitetura.",
+            "ImagemDestino": "porto.jpg",
             "CodigoDestino": "OPO"
         },
         {
@@ -407,12 +407,21 @@
         },
         {
             "id": 46,
-            "Destino": "Porto",
+            "Destino": "Vale do Douro",
+            "Pais": "Portugal",
+            "TipoTurismo": "Rural",
+            "Descricao": "Paisagem deslumbrante de vinhas em socalcos ao longo do rio Douro, berço do Vinho do Porto.",
+            "ImagemDestino": "valedodouro.jpg",
+            "CodigoDestino": "OPO"
+        },
+        {
+            "id": 47,
+            "Destino": "Lisboa",
             "Pais": "Portugal",
             "TipoTurismo": "Cultural",
-            "Descricao": "Cidade histórica do norte de Portugal, famosa pelo vinho do Porto e arquitetura.",
-            "ImagemDestino": "porto.jpg",
-            "CodigoDestino": "OPO"
+            "Descricao": "Capital de Portugal, famosa pelas suas colinas, azulejos, fado e rica história marítima.",
+            "ImagemDestino": "lisboa.jpg",
+            "CodigoDestino": "LIS"
         }
     ]
 }

--- a/js/data/destinations.json
+++ b/js/data/destinations.json
@@ -404,6 +404,15 @@
             "Descricao": "A mais alta cadeia montanhosa de Portugal Continental, ideal para caminhadas, queijos e aldeias de xisto.",
             "ImagemDestino": "serradaestrela.jpg",
             "CodigoDestino": "VSE"
+        },
+        {
+            "id": 46,
+            "Destino": "Porto",
+            "Pais": "Portugal",
+            "TipoTurismo": "Cultural",
+            "Descricao": "Cidade histórica do norte de Portugal, famosa pelo vinho do Porto e arquitetura.",
+            "ImagemDestino": "porto.jpg",
+            "CodigoDestino": "OPO"
         }
     ]
 }

--- a/js/data/destinations.json
+++ b/js/data/destinations.json
@@ -6,7 +6,7 @@
             "Pais": "França",
             "TipoTurismo": "Cultural",
             "Descricao": "Conhecida como a Cidade Luz, Paris é famosa pelos seus museus, arquitetura histórica e gastronomia.",
-            "ImagemDestino": "paris.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/1345426734/photo/eiffel-tower-paris-river-seine-sunset-twilight-france.jpg?s=612x612&w=0&k=20&c=I5rAH5d_-Yyag8F0CKzk9vzMr_1rgkAASGTE11YMh9A=",
             "CodigoDestino": "CDG"
         },
         {
@@ -15,7 +15,7 @@
             "Pais": "Brasil",
             "TipoTurismo": "Balnear",
             "Descricao": "Cidade maravilhosa com praias icônicas como Copacabana e Ipanema, além do Cristo Redentor.",
-            "ImagemDestino": "rio_de_janeiro.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/518230906/photo/christ-the-redeemer-in-rio-de-janeiro.jpg?s=612x612&w=0&k=20&c=cCDx5OfxxdLTLLBJmDLCm75JRj1uqFNqbb7J3wZ-ms8=",
             "CodigoDestino": "GIG"
         },
         {
@@ -24,7 +24,7 @@
             "Pais": "Japão",
             "TipoTurismo": "Urbano",
             "Descricao": "Metrópole vibrante que mistura tradição e modernidade, famosa por sua tecnologia e cultura pop.",
-            "ImagemDestino": "toquio.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1540959733332-eab4deabeeaf?w=800&h=600&fit=crop",
             "CodigoDestino": "HND"
         },
         {
@@ -33,7 +33,7 @@
             "Pais": "Itália",
             "TipoTurismo": "Histórico",
             "Descricao": "Cidade eterna, repleta de monumentos antigos como o Coliseu e o Vaticano.",
-            "ImagemDestino": "roma.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1552832230-c0197dd311b5?w=800&h=600&fit=crop",
             "CodigoDestino": "FCO"
         },
         {
@@ -42,7 +42,7 @@
             "Pais": "Cabo Verde",
             "TipoTurismo": "Balnear",
             "Descricao": "Arquipélago africano conhecido pelas suas praias paradisíacas e cultura vibrante.",
-            "ImagemDestino": "cabo_verde.jpg",
+            "ImagemDestino": "https://t4.ftcdn.net/jpg/06/55/86/35/360_F_655863515_URaeQub4L6XZYwjGaXAfPrArRXsNfynq.jpg",
             "CodigoDestino": "RAI"
         },
         {
@@ -51,7 +51,7 @@
             "Pais": "Austrália",
             "TipoTurismo": "Aventura",
             "Descricao": "Famosa pela Opera House, praias e atividades ao ar livre como surf e trilhas.",
-            "ImagemDestino": "sydney.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&h=600&fit=crop",
             "CodigoDestino": "SYD"
         },
         {
@@ -60,7 +60,7 @@
             "Pais": "Estados Unidos",
             "TipoTurismo": "Urbano",
             "Descricao": "A cidade que nunca dorme, famosa pelos seus arranha-céus, Broadway e Central Park.",
-            "ImagemDestino": "nova_iorque.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1496442226666-8d4d0e62e6e9?w=800&h=600&fit=crop",
             "CodigoDestino": "JFK"
         },
         {
@@ -69,7 +69,7 @@
             "Pais": "Espanha",
             "TipoTurismo": "Cultural",
             "Descricao": "Conhecida pela arquitetura de Gaudí, praias e vida noturna animada.",
-            "ImagemDestino": "barcelona.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1539037116277-4db20889f2d4?w=800&h=600&fit=crop",
             "CodigoDestino": "BCN"
         },
         {
@@ -78,7 +78,7 @@
             "Pais": "África do Sul",
             "TipoTurismo": "Aventura",
             "Descricao": "Paisagens deslumbrantes, Table Mountain e praias incríveis.",
-            "ImagemDestino": "cidade_do_cabo.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1580060839134-75a5edca2e99?w=800&h=600&fit=crop",
             "CodigoDestino": "CPT"
         },
         {
@@ -87,7 +87,7 @@
             "Pais": "Tailândia",
             "TipoTurismo": "Exótico",
             "Descricao": "Templos dourados, mercados flutuantes e culinária de rua vibrante.",
-            "ImagemDestino": "bangkok.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/474564386/photo/bangkok-cityscape.jpg?s=612x612&w=0&k=20&c=-cfbfmyX8RfC-v3YtVdQkQb67wJq9SiEBxfJy_A3_Uo=",
             "CodigoDestino": "BKK"
         },
         {
@@ -96,7 +96,7 @@
             "Pais": "Turquia",
             "TipoTurismo": "Histórico",
             "Descricao": "Cidade que une Europa e Ásia, rica em história e cultura.",
-            "ImagemDestino": "istambul.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1541432901042-2d8bd64b4a9b?w=800&h=600&fit=crop",
             "CodigoDestino": "IST"
         },
         {
@@ -105,7 +105,7 @@
             "Pais": "Reino Unido",
             "TipoTurismo": "Cultural",
             "Descricao": "Famosa pelo Big Ben, museus e diversidade cultural.",
-            "ImagemDestino": "londres.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1513635269975-59663e0ac1ad?w=800&h=600&fit=crop",
             "CodigoDestino": "LHR"
         },
         {
@@ -114,7 +114,7 @@
             "Pais": "Emirados Árabes Unidos",
             "TipoTurismo": "Luxo",
             "Descricao": "Arranha-céus futuristas, shoppings e experiências no deserto.",
-            "ImagemDestino": "dubai.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1512453979798-5ea266f8880c?w=800&h=600&fit=crop",
             "CodigoDestino": "DXB"
         },
         {
@@ -123,16 +123,16 @@
             "Pais": "Peru",
             "TipoTurismo": "Aventura",
             "Descricao": "Antiga cidade inca nas montanhas, destino de trilhas e história.",
-            "ImagemDestino": "machu_picchu.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1587595431973-160d0d94add1?w=800&h=600&fit=crop",
             "CodigoDestino": "CUZ"
         },
         {
             "id": 15,
-            "Destino": "Amsterdã",
+            "Destino": "Amsterdão",
             "Pais": "Países Baixos",
             "TipoTurismo": "Cultural",
             "Descricao": "Canais pitorescos, museus renomados e bicicletas por toda parte.",
-            "ImagemDestino": "amsterda.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1534351590666-13e3e96b5017?w=800&h=600&fit=crop",
             "CodigoDestino": "AMS"
         },
         {
@@ -141,7 +141,7 @@
             "Pais": "Maldivas",
             "TipoTurismo": "Balnear",
             "Descricao": "Ilhas paradisíacas com águas cristalinas e resorts de luxo.",
-            "ImagemDestino": "maldivas.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/1348963437/pt/foto/foot-path-to-jetty.jpg?s=612x612&w=0&k=20&c=Nk7ADQQPj7uPipJCA-PIE-VxXJt-A7V_wdhy22QozXQ=",
             "CodigoDestino": "MLE"
         },
         {
@@ -150,7 +150,7 @@
             "Pais": "Áustria",
             "TipoTurismo": "Cultural",
             "Descricao": "Cidade imperial famosa pela música clássica e arquitetura elegante.",
-            "ImagemDestino": "viena.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1516550893923-42d28e5677af?w=800&h=600&fit=crop",
             "CodigoDestino": "VIE"
         },
         {
@@ -159,7 +159,7 @@
             "Pais": "República Tcheca",
             "TipoTurismo": "Histórico",
             "Descricao": "Cidade medieval com castelos, pontes e ruas de paralelepípedo.",
-            "ImagemDestino": "praga.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1541849546-216549ae216d?w=800&h=600&fit=crop",
             "CodigoDestino": "PRG"
         },
         {
@@ -168,7 +168,7 @@
             "Pais": "Grécia",
             "TipoTurismo": "Balnear",
             "Descricao": "Ilha famosa por suas casas brancas e vistas deslumbrantes do mar Egeu.",
-            "ImagemDestino": "santorini.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1570077188670-e3a8d69ac5ff?w=800&h=600&fit=crop",
             "CodigoDestino": "JTR"
         },
         {
@@ -177,7 +177,7 @@
             "Pais": "Canadá",
             "TipoTurismo": "Urbano",
             "Descricao": "Cidade multicultural com a famosa CN Tower e vida urbana vibrante.",
-            "ImagemDestino": "toronto.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1517935706615-2717063c2225?w=800&h=600&fit=crop",
             "CodigoDestino": "YYZ"
         },
         {
@@ -186,7 +186,7 @@
             "Pais": "Jordânia",
             "TipoTurismo": "Histórico",
             "Descricao": "Antiga cidade esculpida na rocha, uma das maravilhas do mundo.",
-            "ImagemDestino": "petra.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/1145273675/photo/spectacular-view-of-two-beautiful-camels-in-front-of-al-khazneh-in-petra-petra-is-a.jpg?s=612x612&w=0&k=20&c=Ofb9Hw7PrOrMELjbhn851YVH339zGKcEva-fS5x71B0=",
             "CodigoDestino": "AMM"
         },
         {
@@ -195,7 +195,7 @@
             "Pais": "Portugal",
             "TipoTurismo": "Balnear",
             "Descricao": "Região sul de Portugal famosa pelas suas praias douradas, falésias e grutas marinhas.",
-            "ImagemDestino": "algarve.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1551632811-561732d1e306?w=800&h=600&fit=crop",
             "CodigoDestino": "FAO"
         },
         {
@@ -204,7 +204,7 @@
             "Pais": "Peru",
             "TipoTurismo": "Gastronómico",
             "Descricao": "Considerada a capital gastronómica da América Latina, famosa pelo ceviche e cozinha de fusão.",
-            "ImagemDestino": "lima.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1531968455001-5c5272a41129?w=800&h=600&fit=crop",
             "CodigoDestino": "LIM"
         },
         {
@@ -213,7 +213,7 @@
             "Pais": "Portugal",
             "TipoTurismo": "Religioso",
             "Descricao": "Um dos mais importantes santuários marianos do mundo, atraindo milhões de peregrinos católicos.",
-            "ImagemDestino": "fatima.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/487264016/pt/foto/portugal-cat%C3%B3lica-peregrina%C3%A7%C3%A3o-centro.jpg?s=612x612&w=0&k=20&c=FC6NuTKMb5CX3FGt1Tjgk6nb7QaVfyJ9TGDDsCEpHr4=",
             "CodigoDestino": "LIS"
         },
         {
@@ -222,7 +222,7 @@
             "Pais": "Itália",
             "TipoTurismo": "Rural",
             "Descricao": "Região de colinas ondulantes, vinhas, olivais e cidades medievais pitorescas.",
-            "ImagemDestino": "toscana.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1523906834658-6e24ef2386f9?w=800&h=600&fit=crop",
             "CodigoDestino": "FLR"
         },
         {
@@ -231,7 +231,7 @@
             "Pais": "México",
             "TipoTurismo": "Balnear",
             "Descricao": "Destino caribenho com praias de areia branca, águas azul-turquesa e recifes de coral.",
-            "ImagemDestino": "cancun.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1552733407-5d5c46c3bb3b?w=800&h=600&fit=crop",
             "CodigoDestino": "CUN"
         },
         {
@@ -240,7 +240,7 @@
             "Pais": "Itália",
             "TipoTurismo": "Gastronómico",
             "Descricao": "Conhecida como 'La Grassa' (A Gorda), é o berço do ragù (molho à bolonhesa) e da mortadela.",
-            "ImagemDestino": "bolonha.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/596076562/pt/foto/bologna-cityscape-view.jpg?s=612x612&w=0&k=20&c=-FvihIsl_s8fGTySU2rFr0eHQSl888eArAoAdYfXNb8=",
             "CodigoDestino": "BLQ"
         },
         {
@@ -249,7 +249,7 @@
             "Pais": "Israel",
             "TipoTurismo": "Religioso",
             "Descricao": "Cidade sagrada para o Judaísmo, Cristianismo e Islamismo, com locais como o Muro das Lamentações e o Santo Sepulcro.",
-            "ImagemDestino": "jerusalem.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/1454139661/pt/foto/colorful-sunset-sky-and-an-aerial-view-of-the-arabic-quarter-of-jerusalem.jpg?s=612x612&w=0&k=20&c=4Lm2jFtmEQOuuxcFgURVffJ0_BhroFzf-7UX5pRPIrM=",
             "CodigoDestino": "TLV"
         },
         {
@@ -258,7 +258,7 @@
             "Pais": "França",
             "TipoTurismo": "Rural",
             "Descricao": "Famosa pelos seus campos de lavanda, aldeias encantadoras e mercados ao ar livre.",
-            "ImagemDestino": "provenca.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1499856871958-5b9627545d1a?w=800&h=600&fit=crop",
             "CodigoDestino": "MRS"
         },
         {
@@ -267,7 +267,7 @@
             "Pais": "Polinésia Francesa",
             "TipoTurismo": "Balnear",
             "Descricao": "Ilha de luxo conhecida pelos seus bungalows sobre a água e lagoas de cor safira.",
-            "ImagemDestino": "borabora.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1544551763-46a013bb70d5?w=800&h=600&fit=crop",
             "CodigoDestino": "BOB"
         },
         {
@@ -276,7 +276,7 @@
             "Pais": "França",
             "TipoTurismo": "Gastronómico",
             "Descricao": "Capital da gastronomia francesa, famosa pelos seus 'bouchons' (restaurantes tradicionais).",
-            "ImagemDestino": "lyon.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/1351435368/photo/lyon-france-panoramic-view-in-summer.jpg?s=612x612&w=0&k=20&c=kiQoCIdkg1Dyr2p7GaObjmk2EcYnvIN9sWiF5Qe2lwk=",
             "CodigoDestino": "LYS"
         },
         {
@@ -285,7 +285,7 @@
             "Pais": "Arábia Saudita",
             "TipoTurismo": "Religioso",
             "Descricao": "A cidade mais sagrada do Islamismo, destino da peregrinação anual do Hajj.",
-            "ImagemDestino": "meca.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1591604129939-f1efa4d9f7fa?w=800&h=600&fit=crop",
             "CodigoDestino": "JED"
         },
         {
@@ -294,7 +294,7 @@
             "Pais": "Portugal",
             "TipoTurismo": "Cultural",
             "Descricao": "Cidade histórica do norte de Portugal, famosa pelo vinho do Porto e arquitetura.",
-            "ImagemDestino": "porto.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1555881400-74d7acaacd8b?w=800&h=600&fit=crop",
             "CodigoDestino": "OPO"
         },
         {
@@ -303,7 +303,7 @@
             "Pais": "Tailândia",
             "TipoTurismo": "Balnear",
             "Descricao": "A maior ilha da Tailândia, com praias vibrantes, vida noturna e retiros tranquilos.",
-            "ImagemDestino": "phuket.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/1396081944/photo/thai-traditional-wooden-longtail-boat-and-beautiful-beach-in-phuket-province-thailand.jpg?s=612x612&w=0&k=20&c=VHcWj6C19sECSimcfE3Tf6txxV_0NWHjQFc0xFj5P68=",
             "CodigoDestino": "HKT"
         },
         {
@@ -312,7 +312,7 @@
             "Pais": "Espanha",
             "TipoTurismo": "Gastronómico",
             "Descricao": "Cidade basca célebre pela sua alta concentração de estrelas Michelin e cultura de 'pintxos'.",
-            "ImagemDestino": "sansebastian.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/1482977380/pt/foto/panoramic-view-of-san-sebastian.jpg?s=612x612&w=0&k=20&c=2BMBwoDsVNzgC-caq2knmUSiWVPPcLXa6lP8x2bLiWg=",
             "CodigoDestino": "EAS"
         },
         {
@@ -321,7 +321,7 @@
             "Pais": "Índia",
             "TipoTurismo": "Religioso",
             "Descricao": "Cidade sagrada para os hindus, onde peregrinos se banham no rio Ganges para purificação espiritual.",
-            "ImagemDestino": "varanasi.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1564507592333-c60657eea523?w=800&h=600&fit=crop",
             "CodigoDestino": "VNS"
         },
         {
@@ -330,7 +330,7 @@
             "Pais": "Inglaterra",
             "TipoTurismo": "Rural",
             "Descricao": "Área de beleza natural excecional com aldeias de pedra cor de mel, colinas e jardins encantadores.",
-            "ImagemDestino": "cotswolds.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/1279884619/photo/view-of-castle-combe-village-in-england.jpg?s=612x612&w=0&k=20&c=mqtJlwLWSm3kN2lXN3Oiqr6mMansA-HJfzoTVlW-bfU=",
             "CodigoDestino": "BHX"
         },
         {
@@ -339,7 +339,7 @@
             "Pais": "Espanha",
             "TipoTurismo": "Balnear",
             "Descricao": "Famosa mundialmente pela sua vida noturna, mas também possui praias tranquilas e vilas boémias.",
-            "ImagemDestino": "ibiza.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/849390740/photo/cala-dhort-beach.jpg?s=612x612&w=0&k=20&c=whpq4upULxX2wW4zm-h-lZ1cvXLNO4Z-igVc2Lbc0nc=",
             "CodigoDestino": "IBZ"
         },
         {
@@ -348,7 +348,7 @@
             "Pais": "México",
             "TipoTurismo": "Gastronómico",
             "Descricao": "Berço do mole e do mezcal, com uma rica tradição culinária indígena.",
-            "ImagemDestino": "oaxaca.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/1088463742/photo/landmark-santo-domingo-cathedral-in-historic-oaxaca-city-center.jpg?s=612x612&w=0&k=20&c=ePpA1UeTZqR_DhHZDe4X1KXEsTvgnWeK-POnd8Rsz28=",
             "CodigoDestino": "OAX"
         },
         {
@@ -357,7 +357,7 @@
             "Pais": "Espanha",
             "TipoTurismo": "Religioso",
             "Descricao": "Destino final do famoso caminho de peregrinação 'Caminho de Santiago', onde se acredita estar o túmulo do apóstolo Santiago.",
-            "ImagemDestino": "santiagodecompostela.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1551698618-1dfe5d97d256?w=800&h=600&fit=crop",
             "CodigoDestino": "SCQ"
         },
         {
@@ -366,7 +366,7 @@
             "Pais": "Irlanda",
             "TipoTurismo": "Rural",
             "Descricao": "Região de paisagens selvagens e acidentadas, com lagos, montanhas e uma forte cultura gaélica.",
-            "ImagemDestino": "connemara.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/895544406/photo/landscape-of-the-coast-of-connemara.jpg?s=612x612&w=0&k=20&c=pXWbUXY2GCcSJ8yaoCFQou7Fur8NibKBvsCedjhHGhE=",
             "CodigoDestino": "SNN"
         },
         {
@@ -375,7 +375,7 @@
             "Pais": "Grécia",
             "TipoTurismo": "Balnear",
             "Descricao": "A maior ilha grega, oferecendo uma mistura de praias deslumbrantes, montanhas e história antiga.",
-            "ImagemDestino": "creta.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1570077188670-e3a8d69ac5ff?w=800&h=600&fit=crop",
             "CodigoDestino": "HER"
         },
         {
@@ -384,7 +384,7 @@
             "Pais": "Japão",
             "TipoTurismo": "Gastronómico",
             "Descricao": "Centro da cozinha tradicional japonesa 'kaiseki', tofu artesanal e chá matcha de alta qualidade.",
-            "ImagemDestino": "quioto.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1493976040374-85c8e12f0c0e?w=800&h=600&fit=crop",
             "CodigoDestino": "KIX"
         },
         {
@@ -393,7 +393,7 @@
             "Pais": "França",
             "TipoTurismo": "Religioso",
             "Descricao": "Local de aparições marianas, conhecido pelas suas águas curativas e peregrinações.",
-            "ImagemDestino": "lourdes.jpg",
+            "ImagemDestino": "https://media.istockphoto.com/id/602326164/photo/rosary-basilica-in-the-evening-in-lourdes.jpg?s=612x612&w=0&k=20&c=EbiRi7PQtb8te__k-bZ1Q52qVv_QUAEvfWewomnhu1w=",
             "CodigoDestino": "LDE"
         },
         {
@@ -402,7 +402,7 @@
             "Pais": "Portugal",
             "TipoTurismo": "Rural",
             "Descricao": "A mais alta cadeia montanhosa de Portugal Continental, ideal para caminhadas, queijos e aldeias de xisto.",
-            "ImagemDestino": "serradaestrela.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&h=600&fit=crop",
             "CodigoDestino": "VSE"
         },
         {
@@ -411,7 +411,7 @@
             "Pais": "Portugal",
             "TipoTurismo": "Rural",
             "Descricao": "Paisagem deslumbrante de vinhas em socalcos ao longo do rio Douro, berço do Vinho do Porto.",
-            "ImagemDestino": "valedodouro.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1563986768711-b3bde3dc821e?w=800&h=600&fit=crop",
             "CodigoDestino": "OPO"
         },
         {
@@ -420,7 +420,7 @@
             "Pais": "Portugal",
             "TipoTurismo": "Cultural",
             "Descricao": "Capital de Portugal, famosa pelas suas colinas, azulejos, fado e rica história marítima.",
-            "ImagemDestino": "lisboa.jpg",
+            "ImagemDestino": "https://images.unsplash.com/photo-1555881400-74d7acaacd8b?w=800&h=600&fit=crop",
             "CodigoDestino": "LIS"
         }
     ]

--- a/js/data/destinations.json
+++ b/js/data/destinations.json
@@ -188,6 +188,222 @@
             "Descricao": "Antiga cidade esculpida na rocha, uma das maravilhas do mundo.",
             "ImagemDestino": "petra.jpg",
             "CodigoDestino": "AMM"
+        },
+        {
+            "id": 22,
+            "Destino": "Algarve",
+            "Pais": "Portugal",
+            "TipoTurismo": "Balnear",
+            "Descricao": "Região sul de Portugal famosa pelas suas praias douradas, falésias e grutas marinhas.",
+            "ImagemDestino": "algarve.jpg",
+            "CodigoDestino": "FAO"
+        },
+        {
+            "id": 23,
+            "Destino": "Lima",
+            "Pais": "Peru",
+            "TipoTurismo": "Gastronómico",
+            "Descricao": "Considerada a capital gastronómica da América Latina, famosa pelo ceviche e cozinha de fusão.",
+            "ImagemDestino": "lima.jpg",
+            "CodigoDestino": "LIM"
+        },
+        {
+            "id": 24,
+            "Destino": "Fátima",
+            "Pais": "Portugal",
+            "TipoTurismo": "Religioso",
+            "Descricao": "Um dos mais importantes santuários marianos do mundo, atraindo milhões de peregrinos católicos.",
+            "ImagemDestino": "fatima.jpg",
+            "CodigoDestino": "LIS"
+        },
+        {
+            "id": 25,
+            "Destino": "Toscana",
+            "Pais": "Itália",
+            "TipoTurismo": "Rural",
+            "Descricao": "Região de colinas ondulantes, vinhas, olivais e cidades medievais pitorescas.",
+            "ImagemDestino": "toscana.jpg",
+            "CodigoDestino": "FLR"
+        },
+        {
+            "id": 26,
+            "Destino": "Cancún",
+            "Pais": "México",
+            "TipoTurismo": "Balnear",
+            "Descricao": "Destino caribenho com praias de areia branca, águas azul-turquesa e recifes de coral.",
+            "ImagemDestino": "cancun.jpg",
+            "CodigoDestino": "CUN"
+        },
+        {
+            "id": 27,
+            "Destino": "Bolonha",
+            "Pais": "Itália",
+            "TipoTurismo": "Gastronómico",
+            "Descricao": "Conhecida como 'La Grassa' (A Gorda), é o berço do ragù (molho à bolonhesa) e da mortadela.",
+            "ImagemDestino": "bolonha.jpg",
+            "CodigoDestino": "BLQ"
+        },
+        {
+            "id": 28,
+            "Destino": "Jerusalém",
+            "Pais": "Israel",
+            "TipoTurismo": "Religioso",
+            "Descricao": "Cidade sagrada para o Judaísmo, Cristianismo e Islamismo, com locais como o Muro das Lamentações e o Santo Sepulcro.",
+            "ImagemDestino": "jerusalem.jpg",
+            "CodigoDestino": "TLV"
+        },
+        {
+            "id": 29,
+            "Destino": "Provença",
+            "Pais": "França",
+            "TipoTurismo": "Rural",
+            "Descricao": "Famosa pelos seus campos de lavanda, aldeias encantadoras e mercados ao ar livre.",
+            "ImagemDestino": "provenca.jpg",
+            "CodigoDestino": "MRS"
+        },
+        {
+            "id": 30,
+            "Destino": "Bora Bora",
+            "Pais": "Polinésia Francesa",
+            "TipoTurismo": "Balnear",
+            "Descricao": "Ilha de luxo conhecida pelos seus bungalows sobre a água e lagoas de cor safira.",
+            "ImagemDestino": "borabora.jpg",
+            "CodigoDestino": "BOB"
+        },
+        {
+            "id": 31,
+            "Destino": "Lyon",
+            "Pais": "França",
+            "TipoTurismo": "Gastronómico",
+            "Descricao": "Capital da gastronomia francesa, famosa pelos seus 'bouchons' (restaurantes tradicionais).",
+            "ImagemDestino": "lyon.jpg",
+            "CodigoDestino": "LYS"
+        },
+        {
+            "id": 32,
+            "Destino": "Meca",
+            "Pais": "Arábia Saudita",
+            "TipoTurismo": "Religioso",
+            "Descricao": "A cidade mais sagrada do Islamismo, destino da peregrinação anual do Hajj.",
+            "ImagemDestino": "meca.jpg",
+            "CodigoDestino": "JED"
+        },
+        {
+            "id": 33,
+            "Destino": "Vale do Douro",
+            "Pais": "Portugal",
+            "TipoTurismo": "Rural",
+            "Descricao": "Paisagem deslumbrante de vinhas em socalcos ao longo do rio Douro, berço do Vinho do Porto.",
+            "ImagemDestino": "valedodouro.jpg",
+            "CodigoDestino": "OPO"
+        },
+        {
+            "id": 34,
+            "Destino": "Phuket",
+            "Pais": "Tailândia",
+            "TipoTurismo": "Balnear",
+            "Descricao": "A maior ilha da Tailândia, com praias vibrantes, vida noturna e retiros tranquilos.",
+            "ImagemDestino": "phuket.jpg",
+            "CodigoDestino": "HKT"
+        },
+        {
+            "id": 35,
+            "Destino": "San Sebastián",
+            "Pais": "Espanha",
+            "TipoTurismo": "Gastronómico",
+            "Descricao": "Cidade basca célebre pela sua alta concentração de estrelas Michelin e cultura de 'pintxos'.",
+            "ImagemDestino": "sansebastian.jpg",
+            "CodigoDestino": "EAS"
+        },
+        {
+            "id": 36,
+            "Destino": "Varanasi",
+            "Pais": "Índia",
+            "TipoTurismo": "Religioso",
+            "Descricao": "Cidade sagrada para os hindus, onde peregrinos se banham no rio Ganges para purificação espiritual.",
+            "ImagemDestino": "varanasi.jpg",
+            "CodigoDestino": "VNS"
+        },
+        {
+            "id": 37,
+            "Destino": "Cotswolds",
+            "Pais": "Inglaterra",
+            "TipoTurismo": "Rural",
+            "Descricao": "Área de beleza natural excecional com aldeias de pedra cor de mel, colinas e jardins encantadores.",
+            "ImagemDestino": "cotswolds.jpg",
+            "CodigoDestino": "BHX"
+        },
+        {
+            "id": 38,
+            "Destino": "Ibiza",
+            "Pais": "Espanha",
+            "TipoTurismo": "Balnear",
+            "Descricao": "Famosa mundialmente pela sua vida noturna, mas também possui praias tranquilas e vilas boémias.",
+            "ImagemDestino": "ibiza.jpg",
+            "CodigoDestino": "IBZ"
+        },
+        {
+            "id": 39,
+            "Destino": "Oaxaca",
+            "Pais": "México",
+            "TipoTurismo": "Gastronómico",
+            "Descricao": "Berço do mole e do mezcal, com uma rica tradição culinária indígena.",
+            "ImagemDestino": "oaxaca.jpg",
+            "CodigoDestino": "OAX"
+        },
+        {
+            "id": 40,
+            "Destino": "Santiago de Compostela",
+            "Pais": "Espanha",
+            "TipoTurismo": "Religioso",
+            "Descricao": "Destino final do famoso caminho de peregrinação 'Caminho de Santiago', onde se acredita estar o túmulo do apóstolo Santiago.",
+            "ImagemDestino": "santiagodecompostela.jpg",
+            "CodigoDestino": "SCQ"
+        },
+        {
+            "id": 41,
+            "Destino": "Connemara",
+            "Pais": "Irlanda",
+            "TipoTurismo": "Rural",
+            "Descricao": "Região de paisagens selvagens e acidentadas, com lagos, montanhas e uma forte cultura gaélica.",
+            "ImagemDestino": "connemara.jpg",
+            "CodigoDestino": "SNN"
+        },
+        {
+            "id": 42,
+            "Destino": "Creta",
+            "Pais": "Grécia",
+            "TipoTurismo": "Balnear",
+            "Descricao": "A maior ilha grega, oferecendo uma mistura de praias deslumbrantes, montanhas e história antiga.",
+            "ImagemDestino": "creta.jpg",
+            "CodigoDestino": "HER"
+        },
+        {
+            "id": 43,
+            "Destino": "Quioto",
+            "Pais": "Japão",
+            "TipoTurismo": "Gastronómico",
+            "Descricao": "Centro da cozinha tradicional japonesa 'kaiseki', tofu artesanal e chá matcha de alta qualidade.",
+            "ImagemDestino": "quioto.jpg",
+            "CodigoDestino": "KIX"
+        },
+        {
+            "id": 44,
+            "Destino": "Lourdes",
+            "Pais": "França",
+            "TipoTurismo": "Religioso",
+            "Descricao": "Local de aparições marianas, conhecido pelas suas águas curativas e peregrinações.",
+            "ImagemDestino": "lourdes.jpg",
+            "CodigoDestino": "LDE"
+        },
+        {
+            "id": 45,
+            "Destino": "Serra da Estrela",
+            "Pais": "Portugal",
+            "TipoTurismo": "Rural",
+            "Descricao": "A mais alta cadeia montanhosa de Portugal Continental, ideal para caminhadas, queijos e aldeias de xisto.",
+            "ImagemDestino": "serradaestrela.jpg",
+            "CodigoDestino": "VSE"
         }
     ]
 }

--- a/js/data/flight.json
+++ b/js/data/flight.json
@@ -107,7 +107,7 @@
             "layover": false,
             "airline": {
                 "name": "Cabo Verde Airlines",
-                "logo": "https://example.com/logos/caboverde.png"
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/f/fc/Cabo_Verde_Airlines_logo.png"
             }
         },
         {
@@ -317,7 +317,7 @@
             },
             "arrival": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdãoo",
                 "date": "2024-07-15T16:45:00"
             },
             "price": 185.00,
@@ -2131,7 +2131,7 @@
             "layover": false,
             "airline": {
                 "name": "Cabo Verde Airlines",
-                "logo": "https://example.com/logos/caboverde.png"
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/f/fc/Cabo_Verde_Airlines_logo.png"
             }
         },
         {
@@ -2341,7 +2341,7 @@
             },
             "arrival": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-08-27T15:30:00"
             },
             "price": 75.00,
@@ -2358,7 +2358,7 @@
             "id": 108,
             "departure": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-08-27T17:30:00"
             },
             "arrival": {
@@ -2517,7 +2517,7 @@
             },
             "arrival": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-08-31T13:00:00"
             },
             "price": 95.00,
@@ -2534,7 +2534,7 @@
             "id": 116,
             "departure": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-08-31T15:00:00"
             },
             "arrival": {
@@ -2561,7 +2561,7 @@
             },
             "arrival": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-09-01T14:30:00"
             },
             "price": 125.00,
@@ -2578,7 +2578,7 @@
             "id": 118,
             "departure": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-09-01T16:30:00"
             },
             "arrival": {
@@ -2952,7 +2952,7 @@
             "id": 135,
             "departure": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-09-10T12:45:00"
             },
             "arrival": {
@@ -2979,7 +2979,7 @@
             },
             "arrival": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-09-10T19:15:00"
             },
             "price": 150.00,
@@ -2996,7 +2996,7 @@
             "id": 137,
             "departure": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-09-11T08:30:00"
             },
             "arrival": {
@@ -3023,7 +3023,7 @@
             },
             "arrival": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-09-11T14:30:00"
             },
             "price": 140.00,
@@ -3304,7 +3304,7 @@
             "id": 151,
             "departure": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-09-18T12:15:00"
             },
             "arrival": {
@@ -3331,7 +3331,7 @@
             },
             "arrival": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-09-18T21:15:00"
             },
             "price": 210.00,
@@ -3568,7 +3568,7 @@
             "id": 163,
             "departure": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-09-24T19:30:00"
             },
             "arrival": {
@@ -3595,7 +3595,7 @@
             },
             "arrival": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-09-25T12:30:00"
             },
             "price": 475.00,
@@ -3920,7 +3920,7 @@
             "id": 179,
             "departure": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-10-02T14:30:00"
             },
             "arrival": {
@@ -3947,7 +3947,7 @@
             },
             "arrival": {
                 "code": "AMS",
-                "city": "Amsterdã",
+                "city": "Amsterdão",
                 "date": "2024-10-03T09:30:00"
             },
             "price": 395.00,

--- a/js/data/flight.json
+++ b/js/data/flight.json
@@ -3,12 +3,12 @@
         {
             "id": 1,
             "departure": {
-                "code": "LIS",
-                "city": "Lisboa",
+                "code": "OPO",
+                "city": "Porto",
                 "date": "2024-07-01T08:00:00"
             },
             "arrival": {
-                "code": "PAR",
+                "code": "CDG",
                 "city": "Paris",
                 "date": "2024-07-01T10:30:00"
             },
@@ -25,128 +25,260 @@
         {
             "id": 2,
             "departure": {
-                "code": "OPO",
-                "city": "Porto",
+                "code": "LIS",
+                "city": "Lisboa",
                 "date": "2024-07-02T09:15:00"
             },
             "arrival": {
-                "code": "MAD",
-                "city": "Madrid",
-                "date": "2024-07-02T10:35:00"
+                "code": "GIG",
+                "city": "Rio de Janeiro",
+                "date": "2024-07-02T14:45:00"
             },
-            "price": 95.00,
+            "price": 450.00,
             "people": 1,
-            "flightTime": "1h 20m",
+            "flightTime": "9h 30m",
             "direct": true,
             "layover": false,
             "airline": {
-                "name": "Ryanair",
-                "logo": "https://logos-world.net/wp-content/uploads/2020/03/Ryanair-Logo-2013-present.jpg"
+                "name": "TAP Air Portugal",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/TAP_Portugal_Logo.svg/2560px-TAP_Portugal_Logo.svg.png"
             }
         },
         {
             "id": 3,
             "departure": {
-                "code": "LIS",
-                "city": "Lisboa",
-                "date": "2024-07-03T12:00:00"
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-03T11:20:00"
             },
             "arrival": {
-                "code": "JFK",
-                "city": "Nova Iorque",
-                "date": "2024-07-03T22:15:00"
+                "code": "HND",
+                "city": "Tóquio",
+                "date": "2024-07-04T08:45:00"
             },
-            "price": 650.00,
-            "people": 3,
-            "flightTime": "10h 15m",
+            "price": 890.00,
+            "people": 2,
+            "flightTime": "13h 25m",
             "direct": false,
             "layover": true,
             "airline": {
-                "name": "Lufthansa",
-                "logo": "https://example.com/logos/lufthansa.png"
+                "name": "ANA All Nippon Airways",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8d/All_Nippon_Airways_Logo.svg/2560px-All_Nippon_Airways_Logo.svg.png"
             }
         },
         {
             "id": 4,
             "departure": {
-                "code": "OPO",
-                "city": "Porto",
-                "date": "2024-07-04T07:30:00"
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-04T15:30:00"
             },
             "arrival": {
-                "code": "BCN",
-                "city": "Barcelona",
-                "date": "2024-07-04T09:20:00"
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-07-04T18:15:00"
             },
-            "price": 120.00,
-            "people": 2,
-            "flightTime": "1h 50m",
+            "price": 195.00,
+            "people": 1,
+            "flightTime": "2h 45m",
             "direct": true,
             "layover": false,
             "airline": {
-                "name": "Iberia",
-                "logo": "https://example.com/logos/iberia.png"
+                "name": "Alitalia",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Alitalia_logo_2017.png/1200px-Alitalia_logo_2017.png"
             }
         },
         {
             "id": 5,
             "departure": {
-                "code": "LIS",
-                "city": "Lisboa",
-                "date": "2024-07-05T14:00:00"
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-05T07:45:00"
             },
             "arrival": {
-                "code": "FCO",
-                "city": "Roma",
-                "date": "2024-07-05T17:00:00"
+                "code": "RAI",
+                "city": "Cabo Verde",
+                "date": "2024-07-05T12:30:00"
             },
-            "price": 210.00,
-            "people": 1,
-            "flightTime": "3h 00m",
-            "direct": false,
-            "layover": true,
+            "price": 280.00,
+            "people": 2,
+            "flightTime": "4h 45m",
+            "direct": true,
+            "layover": false,
             "airline": {
-                "name": "Air France",
-                "logo": "https://example.com/logos/airfrance.png"
+                "name": "Cabo Verde Airlines",
+                "logo": "https://example.com/logos/caboverde.png"
             }
         },
         {
             "id": 6,
             "departure": {
-                "code": "OPO",
-                "city": "Porto",
-                "date": "2024-07-06T06:45:00"
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-06T10:00:00"
             },
             "arrival": {
-                "code": "LHR",
-                "city": "Londres",
-                "date": "2024-07-06T09:10:00"
+                "code": "SYD",
+                "city": "Sydney",
+                "date": "2024-07-07T18:30:00"
             },
-            "price": 160.00,
-            "people": 2,
-            "flightTime": "2h 25m",
-            "direct": true,
-            "layover": false,
+            "price": 1200.00,
+            "people": 1,
+            "flightTime": "22h 30m",
+            "direct": false,
+            "layover": true,
             "airline": {
-                "name": "easyJet",
-                "logo": "https://example.com/logos/easyjet.png"
+                "name": "Qantas",
+                "logo": "https://example.com/logos/qantas.png"
             }
         },
         {
             "id": 7,
             "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-07T14:15:00"
+            },
+            "arrival": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-07-07T20:45:00"
+            },
+            "price": 520.00,
+            "people": 2,
+            "flightTime": "8h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "United Airlines",
+                "logo": "https://example.com/logos/united.png"
+            }
+        },
+        {
+            "id": 8,
+            "departure": {
                 "code": "LIS",
                 "city": "Lisboa",
-                "date": "2024-07-07T15:30:00"
+                "date": "2024-07-08T16:20:00"
+            },
+            "arrival": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-07-08T18:45:00"
+            },
+            "price": 125.00,
+            "people": 1,
+            "flightTime": "2h 25m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Vueling",
+                "logo": "https://example.com/logos/vueling.png"
+            }
+        },
+        {
+            "id": 9,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-09T08:30:00"
+            },
+            "arrival": {
+                "code": "CPT",
+                "city": "Cidade do Cabo",
+                "date": "2024-07-09T19:15:00"
+            },
+            "price": 850.00,
+            "people": 2,
+            "flightTime": "10h 45m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "South African Airways",
+                "logo": "https://example.com/logos/saa.png"
+            }
+        },
+        {
+            "id": 10,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-10T12:00:00"
+            },
+            "arrival": {
+                "code": "BKK",
+                "city": "Bangkok",
+                "date": "2024-07-11T06:30:00"
+            },
+            "price": 680.00,
+            "people": 1,
+            "flightTime": "12h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Thai Airways",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3e/Thai_Airways_logo.svg/2560px-Thai_Airways_logo.svg.png"
+            }
+        },
+        {
+            "id": 11,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-11T18:45:00"
+            },
+            "arrival": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-07-12T02:15:00"
+            },
+            "price": 320.00,
+            "people": 2,
+            "flightTime": "5h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 12,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-12T09:30:00"
+            },
+            "arrival": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-07-12T12:15:00"
+            },
+            "price": 165.00,
+            "people": 1,
+            "flightTime": "2h 45m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "British Airways",
+                "logo": "https://example.com/logos/ba.png"
+            }
+        },
+        {
+            "id": 13,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-13T21:00:00"
             },
             "arrival": {
                 "code": "DXB",
                 "city": "Dubai",
-                "date": "2024-07-07T23:55:00"
+                "date": "2024-07-14T08:30:00"
             },
-            "price": 780.00,
-            "people": 1,
-            "flightTime": "7h 25m",
+            "price": 580.00,
+            "people": 2,
+            "flightTime": "7h 30m",
             "direct": true,
             "layover": false,
             "airline": {
@@ -155,69 +287,4117 @@
             }
         },
         {
-            "id": 8,
-            "departure": {
-                "code": "OPO",
-                "city": "Porto",
-                "date": "2024-07-08T11:00:00"
-            },
-            "arrival": {
-                "code": "ZRH",
-                "city": "Zurique",
-                "date": "2024-07-08T14:30:00"
-            },
-            "price": 230.00,
-            "people": 1,
-            "flightTime": "2h 30m",
-            "direct": false,
-            "layover": true,
-            "airline": {
-                "name": "SWISS",
-                "logo": "https://example.com/logos/swiss.png"
-            }
-        },
-        {
-            "id": 9,
+            "id": 14,
             "departure": {
                 "code": "LIS",
                 "city": "Lisboa",
-                "date": "2024-07-09T10:20:00"
+                "date": "2024-07-14T06:15:00"
+            },
+            "arrival": {
+                "code": "CUZ",
+                "city": "Machu Picchu",
+                "date": "2024-07-14T18:45:00"
+            },
+            "price": 780.00,
+            "people": 1,
+            "flightTime": "14h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "LATAM Airlines",
+                "logo": "https://example.com/logos/latam.png"
+            }
+        },
+        {
+            "id": 15,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-15T13:20:00"
             },
             "arrival": {
                 "code": "AMS",
-                "city": "Amesterdão",
-                "date": "2024-07-09T14:00:00"
+                "city": "Amsterdã",
+                "date": "2024-07-15T16:45:00"
             },
-            "price": 195.00,
+            "price": 185.00,
             "people": 2,
-            "flightTime": "3h 40m",
-            "direct": false,
-            "layover": true,
+            "flightTime": "3h 25m",
+            "direct": true,
+            "layover": false,
             "airline": {
                 "name": "KLM",
                 "logo": "https://example.com/logos/klm.png"
             }
         },
         {
-            "id": 10,
+            "id": 16,
             "departure": {
                 "code": "LIS",
                 "city": "Lisboa",
-                "date": "2024-07-10T21:00:00"
+                "date": "2024-07-16T11:45:00"
             },
             "arrival": {
-                "code": "DOH",
-                "city": "Doha",
-                "date": "2024-07-11T06:30:00"
+                "code": "MLE",
+                "city": "Maldivas",
+                "date": "2024-07-17T05:30:00"
             },
-            "price": 820.00,
+            "price": 950.00,
+            "people": 1,
+            "flightTime": "11h 45m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Qatar Airways",
+                "logo": "https://example.com/logos/qatar.png"
+            }
+        },
+        {
+            "id": 17,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-17T15:00:00"
+            },
+            "arrival": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-07-17T19:15:00"
+            },
+            "price": 220.00,
+            "people": 2,
+            "flightTime": "4h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 18,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-18T08:45:00"
+            },
+            "arrival": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-07-18T13:30:00"
+            },
+            "price": 240.00,
+            "people": 1,
+            "flightTime": "4h 45m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Czech Airlines",
+                "logo": "https://example.com/logos/czech.png"
+            }
+        },
+        {
+            "id": 19,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-19T12:30:00"
+            },
+            "arrival": {
+                "code": "JTR",
+                "city": "Santorini",
+                "date": "2024-07-19T18:45:00"
+            },
+            "price": 285.00,
+            "people": 2,
+            "flightTime": "6h 15m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Aegean Airlines",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/9/94/Aegean_Airlines_Logo_2020.png"
+            }
+        },
+        {
+            "id": 20,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-20T17:15:00"
+            },
+            "arrival": {
+                "code": "YYZ",
+                "city": "Toronto",
+                "date": "2024-07-20T22:45:00"
+            },
+            "price": 620.00,
+            "people": 1,
+            "flightTime": "8h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air Canada",
+                "logo": "https://example.com/logos/aircanada.png"
+            }
+        },
+        {
+            "id": 21,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-21T10:20:00"
+            },
+            "arrival": {
+                "code": "AMM",
+                "city": "Petra",
+                "date": "2024-07-21T17:45:00"
+            },
+            "price": 420.00,
+            "people": 2,
+            "flightTime": "5h 25m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Royal Jordanian",
+                "logo": "https://example.com/logos/rj.png"
+            }
+        },
+        {
+            "id": 22,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-22T07:00:00"
+            },
+            "arrival": {
+                "code": "FAO",
+                "city": "Algarve",
+                "date": "2024-07-22T08:00:00"
+            },
+            "price": 85.00,
+            "people": 1,
+            "flightTime": "1h 00m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "TAP Air Portugal",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/TAP_Portugal_Logo.svg/2560px-TAP_Portugal_Logo.svg.png"
+            }
+        },
+        {
+            "id": 23,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-23T14:30:00"
+            },
+            "arrival": {
+                "code": "LIM",
+                "city": "Lima",
+                "date": "2024-07-24T02:15:00"
+            },
+            "price": 720.00,
+            "people": 2,
+            "flightTime": "13h 45m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "LATAM Airlines",
+                "logo": "https://example.com/logos/latam.png"
+            }
+        },
+        {
+            "id": 24,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-24T16:45:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Fátima",
+                "date": "2024-07-24T18:00:00"
+            },
+            "price": 45.00,
+            "people": 1,
+            "flightTime": "1h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "TAP Air Portugal",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/TAP_Portugal_Logo.svg/2560px-TAP_Portugal_Logo.svg.png"
+            }
+        },
+        {
+            "id": 25,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-25T09:15:00"
+            },
+            "arrival": {
+                "code": "FLR",
+                "city": "Toscana",
+                "date": "2024-07-25T13:30:00"
+            },
+            "price": 275.00,
+            "people": 2,
+            "flightTime": "4h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Alitalia",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Alitalia_logo_2017.png/1200px-Alitalia_logo_2017.png"
+            }
+        },
+        {
+            "id": 26,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-26T11:00:00"
+            },
+            "arrival": {
+                "code": "CUN",
+                "city": "Cancún",
+                "date": "2024-07-26T20:30:00"
+            },
+            "price": 650.00,
+            "people": 1,
+            "flightTime": "11h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Aeromexico",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Aeromexico.png"
+            }
+        },
+        {
+            "id": 27,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-27T13:45:00"
+            },
+            "arrival": {
+                "code": "BLQ",
+                "city": "Bolonha",
+                "date": "2024-07-27T17:15:00"
+            },
+            "price": 195.00,
+            "people": 2,
+            "flightTime": "3h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Alitalia",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Alitalia_logo_2017.png/1200px-Alitalia_logo_2017.png"
+            }
+        },
+        {
+            "id": 28,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-28T08:20:00"
+            },
+            "arrival": {
+                "code": "TLV",
+                "city": "Jerusalém",
+                "date": "2024-07-28T15:45:00"
+            },
+            "price": 380.00,
+            "people": 1,
+            "flightTime": "5h 25m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "El Al",
+                "logo": "https://example.com/logos/elal.png"
+            }
+        },
+        {
+            "id": 29,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-29T15:30:00"
+            },
+            "arrival": {
+                "code": "MRS",
+                "city": "Provença",
+                "date": "2024-07-29T18:45:00"
+            },
+            "price": 165.00,
+            "people": 2,
+            "flightTime": "3h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 30,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-30T19:00:00"
+            },
+            "arrival": {
+                "code": "BOB",
+                "city": "Bora Bora",
+                "date": "2024-07-31T14:30:00"
+            },
+            "price": 1350.00,
+            "people": 1,
+            "flightTime": "18h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Air Tahiti Nui",
+                "logo": "https://example.com/logos/airtahiti.png"
+            }
+        },
+        {
+            "id": 31,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-01T10:45:00"
+            },
+            "arrival": {
+                "code": "LYS",
+                "city": "Lyon",
+                "date": "2024-08-01T14:15:00"
+            },
+            "price": 175.00,
+            "people": 2,
+            "flightTime": "3h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 32,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-02T06:30:00"
+            },
+            "arrival": {
+                "code": "JED",
+                "city": "Meca",
+                "date": "2024-08-02T14:45:00"
+            },
+            "price": 580.00,
+            "people": 1,
+            "flightTime": "6h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Saudia",
+                "logo": "https://brandlogos.net/wp-content/uploads/2023/10/saudia_airlines-logo_brandlogos.net_ierhe.png"
+            }
+        },
+        {
+            "id": 33,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-03T12:00:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-03T13:15:00"
+            },
+            "price": 75.00,
+            "people": 2,
+            "flightTime": "1h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "TAP Air Portugal",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/TAP_Portugal_Logo.svg/2560px-TAP_Portugal_Logo.svg.png"
+            }
+        },
+        {
+            "id": 34,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-04T17:20:00"
+            },
+            "arrival": {
+                "code": "HKT",
+                "city": "Phuket",
+                "date": "2024-08-05T11:45:00"
+            },
+            "price": 780.00,
+            "people": 1,
+            "flightTime": "12h 25m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Thai Airways",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3e/Thai_Airways_logo.svg/2560px-Thai_Airways_logo.svg.png"
+            }
+        },
+        {
+            "id": 35,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-05T14:15:00"
+            },
+            "arrival": {
+                "code": "EAS",
+                "city": "San Sebastián",
+                "date": "2024-08-05T16:30:00"
+            },
+            "price": 145.00,
+            "people": 2,
+            "flightTime": "2h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Iberia",
+                "logo": "https://grupo.iberia.com/contents/archives/475/109/images/thumb255x185_auto/af-iberia-vp-rgb-pos-5b503_thumb.jpg"
+            }
+        },
+        {
+            "id": 36,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-06T09:30:00"
+            },
+            "arrival": {
+                "code": "VNS",
+                "city": "Varanasi",
+                "date": "2024-08-06T23:15:00"
+            },
+            "price": 650.00,
+            "people": 1,
+            "flightTime": "11h 45m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Air India",
+                "logo": "https://example.com/logos/airindia.png"
+            }
+        },
+        {
+            "id": 37,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-07T11:45:00"
+            },
+            "arrival": {
+                "code": "BHX",
+                "city": "Cotswolds",
+                "date": "2024-08-07T14:30:00"
+            },
+            "price": 185.00,
+            "people": 2,
+            "flightTime": "2h 45m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "British Airways",
+                "logo": "https://example.com/logos/ba.png"
+            }
+        },
+        {
+            "id": 38,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-08T16:00:00"
+            },
+            "arrival": {
+                "code": "IBZ",
+                "city": "Ibiza",
+                "date": "2024-08-08T18:45:00"
+            },
+            "price": 155.00,
+            "people": 1,
+            "flightTime": "2h 45m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Vueling",
+                "logo": "https://example.com/logos/vueling.png"
+            }
+        },
+        {
+            "id": 39,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-09T08:00:00"
+            },
+            "arrival": {
+                "code": "OAX",
+                "city": "Oaxaca",
+                "date": "2024-08-09T19:30:00"
+            },
+            "price": 680.00,
+            "people": 2,
+            "flightTime": "13h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Aeromexico",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Aeromexico.png"
+            }
+        },
+        {
+            "id": 40,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-10T13:30:00"
+            },
+            "arrival": {
+                "code": "SCQ",
+                "city": "Santiago de Compostela",
+                "date": "2024-08-10T14:45:00"
+            },
+            "price": 95.00,
+            "people": 1,
+            "flightTime": "1h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Iberia",
+                "logo": "https://grupo.iberia.com/contents/archives/475/109/images/thumb255x185_auto/af-iberia-vp-rgb-pos-5b503_thumb.jpg"
+            }
+        },
+        {
+            "id": 41,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-11T10:15:00"
+            },
+            "arrival": {
+                "code": "SNN",
+                "city": "Connemara",
+                "date": "2024-08-11T13:00:00"
+            },
+            "price": 165.00,
+            "people": 2,
+            "flightTime": "2h 45m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Aer Lingus",
+                "logo": "https://wp.logos-download.com/wp-content/uploads/2022/11/Aer_Lingus_Logo.png?dl"
+            }
+        },
+        {
+            "id": 42,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-12T15:45:00"
+            },
+            "arrival": {
+                "code": "HER",
+                "city": "Creta",
+                "date": "2024-08-12T21:30:00"
+            },
+            "price": 295.00,
+            "people": 1,
+            "flightTime": "5h 45m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Aegean Airlines",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/9/94/Aegean_Airlines_Logo_2020.png"
+            }
+        },
+        {
+            "id": 43,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-13T07:30:00"
+            },
+            "arrival": {
+                "code": "KIX",
+                "city": "Quioto",
+                "date": "2024-08-14T02:15:00"
+            },
+            "price": 920.00,
+            "people": 2,
+            "flightTime": "14h 45m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "ANA All Nippon Airways",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8d/All_Nippon_Airways_Logo.svg/2560px-All_Nippon_Airways_Logo.svg.png"
+            }
+        },
+        {
+            "id": 44,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-14T12:20:00"
+            },
+            "arrival": {
+                "code": "LDE",
+                "city": "Lourdes",
+                "date": "2024-08-14T15:45:00"
+            },
+            "price": 135.00,
+            "people": 1,
+            "flightTime": "3h 25m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 45,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-15T18:00:00"
+            },
+            "arrival": {
+                "code": "VSE",
+                "city": "Serra da Estrela",
+                "date": "2024-08-15T19:15:00"
+            },
+            "price": 65.00,
+            "people": 2,
+            "flightTime": "1h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "TAP Air Portugal",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/TAP_Portugal_Logo.svg/2560px-TAP_Portugal_Logo.svg.png"
+            }
+        },
+        {
+            "id": 46,
+            "departure": {
+                "code": "FAO",
+                "city": "Algarve",
+                "date": "2024-07-22T09:00:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-22T10:00:00"
+            },
+            "price": 85.00,
+            "people": 1,
+            "flightTime": "1h 00m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "TAP Air Portugal",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/TAP_Portugal_Logo.svg/2560px-TAP_Portugal_Logo.svg.png"
+            }
+        },
+        {
+            "id": 47,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-23T14:30:00"
+            },
+            "arrival": {
+                "code": "LIM",
+                "city": "Lima",
+                "date": "2024-07-24T02:15:00"
+            },
+            "price": 720.00,
+            "people": 2,
+            "flightTime": "13h 45m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "LATAM Airlines",
+                "logo": "https://example.com/logos/latam.png"
+            }
+        },
+        {
+            "id": 48,
+            "departure": {
+                "code": "LIM",
+                "city": "Lima",
+                "date": "2024-07-24T04:15:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-24T20:00:00"
+            },
+            "price": 735.00,
+            "people": 2,
+            "flightTime": "13h 45m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "LATAM Airlines",
+                "logo": "https://example.com/logos/latam.png"
+            }
+        },
+        {
+            "id": 49,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-24T16:45:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Fátima",
+                "date": "2024-07-24T18:00:00"
+            },
+            "price": 45.00,
+            "people": 1,
+            "flightTime": "1h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "TAP Air Portugal",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/TAP_Portugal_Logo.svg/2560px-TAP_Portugal_Logo.svg.png"
+            }
+        },
+        {
+            "id": 50,
+            "departure": {
+                "code": "LIS",
+                "city": "Fátima",
+                "date": "2024-07-24T19:00:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-24T20:15:00"
+            },
+            "price": 45.00,
+            "people": 1,
+            "flightTime": "1h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "TAP Air Portugal",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/TAP_Portugal_Logo.svg/2560px-TAP_Portugal_Logo.svg.png"
+            }
+        },
+        {
+            "id": 51,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-25T09:15:00"
+            },
+            "arrival": {
+                "code": "FLR",
+                "city": "Toscana",
+                "date": "2024-07-25T13:30:00"
+            },
+            "price": 275.00,
+            "people": 2,
+            "flightTime": "4h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Alitalia",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Alitalia_logo_2017.png/1200px-Alitalia_logo_2017.png"
+            }
+        },
+        {
+            "id": 52,
+            "departure": {
+                "code": "FLR",
+                "city": "Toscana",
+                "date": "2024-07-25T15:30:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-25T19:45:00"
+            },
+            "price": 280.00,
+            "people": 2,
+            "flightTime": "4h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Alitalia",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Alitalia_logo_2017.png/1200px-Alitalia_logo_2017.png"
+            }
+        },
+        {
+            "id": 53,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-26T11:00:00"
+            },
+            "arrival": {
+                "code": "CUN",
+                "city": "Cancún",
+                "date": "2024-07-26T20:30:00"
+            },
+            "price": 650.00,
+            "people": 1,
+            "flightTime": "11h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Aeromexico",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Aeromexico.png"
+            }
+        },
+        {
+            "id": 54,
+            "departure": {
+                "code": "CUN",
+                "city": "Cancún",
+                "date": "2024-07-26T22:30:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-27T18:00:00"
+            },
+            "price": 665.00,
+            "people": 1,
+            "flightTime": "11h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Aeromexico",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Aeromexico.png"
+            }
+        },
+        {
+            "id": 55,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-27T13:45:00"
+            },
+            "arrival": {
+                "code": "BLQ",
+                "city": "Bolonha",
+                "date": "2024-07-27T17:15:00"
+            },
+            "price": 195.00,
+            "people": 2,
+            "flightTime": "3h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Alitalia",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Alitalia_logo_2017.png/1200px-Alitalia_logo_2017.png"
+            }
+        },
+        {
+            "id": 56,
+            "departure": {
+                "code": "BLQ",
+                "city": "Bolonha",
+                "date": "2024-07-27T19:15:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-27T22:45:00"
+            },
+            "price": 200.00,
+            "people": 2,
+            "flightTime": "3h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Alitalia",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Alitalia_logo_2017.png/1200px-Alitalia_logo_2017.png"
+            }
+        },
+        {
+            "id": 57,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-28T08:20:00"
+            },
+            "arrival": {
+                "code": "TLV",
+                "city": "Jerusalém",
+                "date": "2024-07-28T15:45:00"
+            },
+            "price": 380.00,
+            "people": 1,
+            "flightTime": "5h 25m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "El Al",
+                "logo": "https://example.com/logos/elal.png"
+            }
+        },
+        {
+            "id": 58,
+            "departure": {
+                "code": "TLV",
+                "city": "Jerusalém",
+                "date": "2024-07-28T17:45:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-29T01:10:00"
+            },
+            "price": 385.00,
+            "people": 1,
+            "flightTime": "5h 25m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "El Al",
+                "logo": "https://example.com/logos/elal.png"
+            }
+        },
+        {
+            "id": 59,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-29T15:30:00"
+            },
+            "arrival": {
+                "code": "MRS",
+                "city": "Provença",
+                "date": "2024-07-29T18:45:00"
+            },
+            "price": 165.00,
+            "people": 2,
+            "flightTime": "3h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 60,
+            "departure": {
+                "code": "MRS",
+                "city": "Provença",
+                "date": "2024-07-29T20:45:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-07-30T00:00:00"
+            },
+            "price": 170.00,
+            "people": 2,
+            "flightTime": "3h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 61,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-07-30T19:00:00"
+            },
+            "arrival": {
+                "code": "BOB",
+                "city": "Bora Bora",
+                "date": "2024-07-31T14:30:00"
+            },
+            "price": 1350.00,
+            "people": 1,
+            "flightTime": "18h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Air Tahiti Nui",
+                "logo": "https://example.com/logos/airtahiti.png"
+            }
+        },
+        {
+            "id": 62,
+            "departure": {
+                "code": "BOB",
+                "city": "Bora Bora",
+                "date": "2024-07-31T16:30:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-01T21:00:00"
+            },
+            "price": 1365.00,
+            "people": 1,
+            "flightTime": "18h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Air Tahiti Nui",
+                "logo": "https://example.com/logos/airtahiti.png"
+            }
+        },
+        {
+            "id": 63,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-01T10:45:00"
+            },
+            "arrival": {
+                "code": "LYS",
+                "city": "Lyon",
+                "date": "2024-08-01T14:15:00"
+            },
+            "price": 175.00,
+            "people": 2,
+            "flightTime": "3h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 64,
+            "departure": {
+                "code": "LYS",
+                "city": "Lyon",
+                "date": "2024-08-01T16:15:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-01T19:45:00"
+            },
+            "price": 180.00,
+            "people": 2,
+            "flightTime": "3h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 65,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-02T06:30:00"
+            },
+            "arrival": {
+                "code": "JED",
+                "city": "Meca",
+                "date": "2024-08-02T14:45:00"
+            },
+            "price": 580.00,
+            "people": 1,
+            "flightTime": "6h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Saudia",
+                "logo": "https://brandlogos.net/wp-content/uploads/2023/10/saudia_airlines-logo_brandlogos.net_ierhe.png"
+            }
+        },
+        {
+            "id": 66,
+            "departure": {
+                "code": "JED",
+                "city": "Meca",
+                "date": "2024-08-02T16:45:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-03T01:00:00"
+            },
+            "price": 585.00,
+            "people": 1,
+            "flightTime": "6h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Saudia",
+                "logo": "https://brandlogos.net/wp-content/uploads/2023/10/saudia_airlines-logo_brandlogos.net_ierhe.png"
+            }
+        },
+        {
+            "id": 67,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-03T12:00:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-03T13:15:00"
+            },
+            "price": 75.00,
+            "people": 2,
+            "flightTime": "1h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "TAP Air Portugal",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/TAP_Portugal_Logo.svg/2560px-TAP_Portugal_Logo.svg.png"
+            }
+        },
+        {
+            "id": 68,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-03T14:15:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-03T15:30:00"
+            },
+            "price": 75.00,
+            "people": 2,
+            "flightTime": "1h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "TAP Air Portugal",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/TAP_Portugal_Logo.svg/2560px-TAP_Portugal_Logo.svg.png"
+            }
+        },
+        {
+            "id": 69,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-04T17:20:00"
+            },
+            "arrival": {
+                "code": "HKT",
+                "city": "Phuket",
+                "date": "2024-08-05T11:45:00"
+            },
+            "price": 780.00,
+            "people": 1,
+            "flightTime": "12h 25m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Thai Airways",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3e/Thai_Airways_logo.svg/2560px-Thai_Airways_logo.svg.png"
+            }
+        },
+        {
+            "id": 70,
+            "departure": {
+                "code": "HKT",
+                "city": "Phuket",
+                "date": "2024-08-05T13:45:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-06T02:10:00"
+            },
+            "price": 795.00,
+            "people": 1,
+            "flightTime": "12h 25m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Thai Airways",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3e/Thai_Airways_logo.svg/2560px-Thai_Airways_logo.svg.png"
+            }
+        },
+        {
+            "id": 71,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-05T14:15:00"
+            },
+            "arrival": {
+                "code": "EAS",
+                "city": "San Sebastián",
+                "date": "2024-08-05T16:30:00"
+            },
+            "price": 145.00,
+            "people": 2,
+            "flightTime": "2h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Iberia",
+                "logo": "https://grupo.iberia.com/contents/archives/475/109/images/thumb255x185_auto/af-iberia-vp-rgb-pos-5b503_thumb.jpg"
+            }
+        },
+        {
+            "id": 72,
+            "departure": {
+                "code": "EAS",
+                "city": "San Sebastián",
+                "date": "2024-08-05T18:30:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-05T20:45:00"
+            },
+            "price": 150.00,
+            "people": 2,
+            "flightTime": "2h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Iberia",
+                "logo": "https://grupo.iberia.com/contents/archives/475/109/images/thumb255x185_auto/af-iberia-vp-rgb-pos-5b503_thumb.jpg"
+            }
+        },
+        {
+            "id": 73,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-06T09:30:00"
+            },
+            "arrival": {
+                "code": "VNS",
+                "city": "Varanasi",
+                "date": "2024-08-06T23:15:00"
+            },
+            "price": 650.00,
+            "people": 1,
+            "flightTime": "11h 45m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Air India",
+                "logo": "https://example.com/logos/airindia.png"
+            }
+        },
+        {
+            "id": 74,
+            "departure": {
+                "code": "VNS",
+                "city": "Varanasi",
+                "date": "2024-08-07T01:15:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-07T15:00:00"
+            },
+            "price": 665.00,
+            "people": 1,
+            "flightTime": "11h 45m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Air India",
+                "logo": "https://example.com/logos/airindia.png"
+            }
+        },
+        {
+            "id": 75,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-07T11:45:00"
+            },
+            "arrival": {
+                "code": "BHX",
+                "city": "Cotswolds",
+                "date": "2024-08-07T14:30:00"
+            },
+            "price": 185.00,
+            "people": 2,
+            "flightTime": "2h 45m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "British Airways",
+                "logo": "https://example.com/logos/ba.png"
+            }
+        },
+        {
+            "id": 76,
+            "departure": {
+                "code": "BHX",
+                "city": "Cotswolds",
+                "date": "2024-08-07T16:30:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-07T19:15:00"
+            },
+            "price": 190.00,
+            "people": 2,
+            "flightTime": "2h 45m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "British Airways",
+                "logo": "https://example.com/logos/ba.png"
+            }
+        },
+        {
+            "id": 77,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-08T16:00:00"
+            },
+            "arrival": {
+                "code": "IBZ",
+                "city": "Ibiza",
+                "date": "2024-08-08T18:45:00"
+            },
+            "price": 155.00,
+            "people": 1,
+            "flightTime": "2h 45m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Vueling",
+                "logo": "https://example.com/logos/vueling.png"
+            }
+        },
+        {
+            "id": 78,
+            "departure": {
+                "code": "IBZ",
+                "city": "Ibiza",
+                "date": "2024-08-08T20:45:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-08T23:30:00"
+            },
+            "price": 160.00,
+            "people": 1,
+            "flightTime": "2h 45m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Vueling",
+                "logo": "https://example.com/logos/vueling.png"
+            }
+        },
+        {
+            "id": 79,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-09T08:00:00"
+            },
+            "arrival": {
+                "code": "OAX",
+                "city": "Oaxaca",
+                "date": "2024-08-09T19:30:00"
+            },
+            "price": 680.00,
+            "people": 2,
+            "flightTime": "13h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Aeromexico",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Aeromexico.png"
+            }
+        },
+        {
+            "id": 80,
+            "departure": {
+                "code": "OAX",
+                "city": "Oaxaca",
+                "date": "2024-08-09T21:30:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-10T17:00:00"
+            },
+            "price": 695.00,
+            "people": 2,
+            "flightTime": "13h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Aeromexico",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Aeromexico.png"
+            }
+        },
+        {
+            "id": 81,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-10T13:30:00"
+            },
+            "arrival": {
+                "code": "SCQ",
+                "city": "Santiago de Compostela",
+                "date": "2024-08-10T14:45:00"
+            },
+            "price": 95.00,
+            "people": 1,
+            "flightTime": "1h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Iberia",
+                "logo": "https://grupo.iberia.com/contents/archives/475/109/images/thumb255x185_auto/af-iberia-vp-rgb-pos-5b503_thumb.jpg"
+            }
+        },
+        {
+            "id": 82,
+            "departure": {
+                "code": "SCQ",
+                "city": "Santiago de Compostela",
+                "date": "2024-08-10T16:45:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-10T18:00:00"
+            },
+            "price": 100.00,
+            "people": 1,
+            "flightTime": "1h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Iberia",
+                "logo": "https://grupo.iberia.com/contents/archives/475/109/images/thumb255x185_auto/af-iberia-vp-rgb-pos-5b503_thumb.jpg"
+            }
+        },
+        {
+            "id": 83,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-11T10:15:00"
+            },
+            "arrival": {
+                "code": "SNN",
+                "city": "Connemara",
+                "date": "2024-08-11T13:00:00"
+            },
+            "price": 165.00,
+            "people": 2,
+            "flightTime": "2h 45m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Aer Lingus",
+                "logo": "https://wp.logos-download.com/wp-content/uploads/2022/11/Aer_Lingus_Logo.png?dl"
+            }
+        },
+        {
+            "id": 84,
+            "departure": {
+                "code": "SNN",
+                "city": "Connemara",
+                "date": "2024-08-11T15:00:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-11T17:45:00"
+            },
+            "price": 170.00,
+            "people": 2,
+            "flightTime": "2h 45m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Aer Lingus",
+                "logo": "https://wp.logos-download.com/wp-content/uploads/2022/11/Aer_Lingus_Logo.png?dl"
+            }
+        },
+        {
+            "id": 85,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-12T15:45:00"
+            },
+            "arrival": {
+                "code": "HER",
+                "city": "Creta",
+                "date": "2024-08-12T21:30:00"
+            },
+            "price": 295.00,
+            "people": 1,
+            "flightTime": "5h 45m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Aegean Airlines",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/9/94/Aegean_Airlines_Logo_2020.png"
+            }
+        },
+        {
+            "id": 86,
+            "departure": {
+                "code": "HER",
+                "city": "Creta",
+                "date": "2024-08-12T23:30:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-13T05:15:00"
+            },
+            "price": 300.00,
+            "people": 1,
+            "flightTime": "5h 45m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Aegean Airlines",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/9/94/Aegean_Airlines_Logo_2020.png"
+            }
+        },
+        {
+            "id": 87,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-13T07:30:00"
+            },
+            "arrival": {
+                "code": "KIX",
+                "city": "Quioto",
+                "date": "2024-08-14T02:15:00"
+            },
+            "price": 920.00,
+            "people": 2,
+            "flightTime": "14h 45m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "ANA All Nippon Airways",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8d/All_Nippon_Airways_Logo.svg/2560px-All_Nippon_Airways_Logo.svg.png"
+            }
+        },
+        {
+            "id": 88,
+            "departure": {
+                "code": "KIX",
+                "city": "Quioto",
+                "date": "2024-08-14T04:15:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-14T19:00:00"
+            },
+            "price": 935.00,
+            "people": 2,
+            "flightTime": "14h 45m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "ANA All Nippon Airways",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8d/All_Nippon_Airways_Logo.svg/2560px-All_Nippon_Airways_Logo.svg.png"
+            }
+        },
+        {
+            "id": 89,
+            "departure": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-14T12:20:00"
+            },
+            "arrival": {
+                "code": "LDE",
+                "city": "Lourdes",
+                "date": "2024-08-14T15:45:00"
+            },
+            "price": 135.00,
+            "people": 1,
+            "flightTime": "3h 25m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 90,
+            "departure": {
+                "code": "LDE",
+                "city": "Lourdes",
+                "date": "2024-08-14T17:45:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-14T21:10:00"
+            },
+            "price": 140.00,
+            "people": 1,
+            "flightTime": "3h 25m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 91,
+            "departure": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-15T18:00:00"
+            },
+            "arrival": {
+                "code": "VSE",
+                "city": "Serra da Estrela",
+                "date": "2024-08-15T19:15:00"
+            },
+            "price": 65.00,
+            "people": 2,
+            "flightTime": "1h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "TAP Air Portugal",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/TAP_Portugal_Logo.svg/2560px-TAP_Portugal_Logo.svg.png"
+            }
+        },
+        {
+            "id": 92,
+            "departure": {
+                "code": "VSE",
+                "city": "Serra da Estrela",
+                "date": "2024-08-15T20:15:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-15T21:30:00"
+            },
+            "price": 65.00,
+            "people": 2,
+            "flightTime": "1h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "TAP Air Portugal",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/TAP_Portugal_Logo.svg/2560px-TAP_Portugal_Logo.svg.png"
+            }
+        },
+        {
+            "id": 93,
+            "departure": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-08-16T12:30:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-16T15:00:00"
+            },
+            "price": 185.50,
+            "people": 2,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "TAP Air Portugal",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/TAP_Portugal_Logo.svg/2560px-TAP_Portugal_Logo.svg.png"
+            }
+        },
+        {
+            "id": 94,
+            "departure": {
+                "code": "GIG",
+                "city": "Rio de Janeiro",
+                "date": "2024-08-17T16:45:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-18T08:15:00"
+            },
+            "price": 465.00,
+            "people": 1,
+            "flightTime": "9h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "TAP Air Portugal",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/TAP_Portugal_Logo.svg/2560px-TAP_Portugal_Logo.svg.png"
+            }
+        },
+        {
+            "id": 95,
+            "departure": {
+                "code": "HND",
+                "city": "Tóquio",
+                "date": "2024-08-18T10:45:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-19T02:10:00"
+            },
+            "price": 905.00,
+            "people": 2,
+            "flightTime": "13h 25m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "ANA All Nippon Airways",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8d/All_Nippon_Airways_Logo.svg/2560px-All_Nippon_Airways_Logo.svg.png"
+            }
+        },
+        {
+            "id": 96,
+            "departure": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-08-19T20:15:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-19T23:00:00"
+            },
+            "price": 200.00,
+            "people": 1,
+            "flightTime": "2h 45m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Alitalia",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Alitalia_logo_2017.png/1200px-Alitalia_logo_2017.png"
+            }
+        },
+        {
+            "id": 97,
+            "departure": {
+                "code": "RAI",
+                "city": "Cabo Verde",
+                "date": "2024-08-20T14:30:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-20T19:15:00"
+            },
+            "price": 285.00,
+            "people": 2,
+            "flightTime": "4h 45m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Cabo Verde Airlines",
+                "logo": "https://example.com/logos/caboverde.png"
+            }
+        },
+        {
+            "id": 98,
+            "departure": {
+                "code": "SYD",
+                "city": "Sydney",
+                "date": "2024-08-21T20:30:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-22T20:00:00"
+            },
+            "price": 1215.00,
+            "people": 1,
+            "flightTime": "22h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Qantas",
+                "logo": "https://example.com/logos/qantas.png"
+            }
+        },
+        {
+            "id": 99,
+            "departure": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-08-22T22:45:00"
+            },
+            "arrival": {
+                "code": "OPO",
+                "city": "Porto",
+                "date": "2024-08-23T11:15:00"
+            },
+            "price": 535.00,
+            "people": 2,
+            "flightTime": "8h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "United Airlines",
+                "logo": "https://example.com/logos/united.png"
+            }
+        },
+        {
+            "id": 100,
+            "departure": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-08-23T20:45:00"
+            },
+            "arrival": {
+                "code": "LIS",
+                "city": "Lisboa",
+                "date": "2024-08-23T23:10:00"
+            },
+            "price": 130.00,
+            "people": 1,
+            "flightTime": "2h 25m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Vueling",
+                "logo": "https://example.com/logos/vueling.png"
+            }
+        },
+        {
+            "id": 101,
+            "departure": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-08-24T08:00:00"
+            },
+            "arrival": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-08-24T09:30:00"
+            },
+            "price": 95.00,
+            "people": 1,
+            "flightTime": "1h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 102,
+            "departure": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-08-24T11:30:00"
+            },
+            "arrival": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-08-24T13:00:00"
+            },
+            "price": 100.00,
+            "people": 1,
+            "flightTime": "1h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 103,
+            "departure": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-08-25T10:00:00"
+            },
+            "arrival": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-08-25T12:00:00"
+            },
+            "price": 120.00,
+            "people": 2,
+            "flightTime": "2h 00m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 104,
+            "departure": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-08-25T14:00:00"
+            },
+            "arrival": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-08-25T16:00:00"
+            },
+            "price": 125.00,
+            "people": 2,
+            "flightTime": "2h 00m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Alitalia",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Alitalia_logo_2017.png/1200px-Alitalia_logo_2017.png"
+            }
+        },
+        {
+            "id": 105,
+            "departure": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-08-26T12:30:00"
+            },
+            "arrival": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-08-26T13:15:00"
+            },
+            "price": 85.00,
+            "people": 1,
+            "flightTime": "1h 45m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "British Airways",
+                "logo": "https://example.com/logos/ba.png"
+            }
+        },
+        {
+            "id": 106,
+            "departure": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-08-26T15:15:00"
+            },
+            "arrival": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-08-26T18:00:00"
+            },
+            "price": 90.00,
+            "people": 1,
+            "flightTime": "1h 45m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "British Airways",
+                "logo": "https://example.com/logos/ba.png"
+            }
+        },
+        {
+            "id": 107,
+            "departure": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-08-27T14:00:00"
+            },
+            "arrival": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-08-27T15:30:00"
+            },
+            "price": 75.00,
+            "people": 2,
+            "flightTime": "1h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "KLM",
+                "logo": "https://example.com/logos/klm.png"
+            }
+        },
+        {
+            "id": 108,
+            "departure": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-08-27T17:30:00"
+            },
+            "arrival": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-08-27T19:00:00"
+            },
+            "price": 80.00,
+            "people": 2,
+            "flightTime": "1h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "KLM",
+                "logo": "https://example.com/logos/klm.png"
+            }
+        },
+        {
+            "id": 109,
+            "departure": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-08-28T09:00:00"
+            },
+            "arrival": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-08-28T11:00:00"
+            },
+            "price": 110.00,
+            "people": 1,
+            "flightTime": "2h 00m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Vueling",
+                "logo": "https://example.com/logos/vueling.png"
+            }
+        },
+        {
+            "id": 110,
+            "departure": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-08-28T13:00:00"
+            },
+            "arrival": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-08-28T15:00:00"
+            },
+            "price": 115.00,
+            "people": 1,
+            "flightTime": "2h 00m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Alitalia",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Alitalia_logo_2017.png/1200px-Alitalia_logo_2017.png"
+            }
+        },
+        {
+            "id": 111,
+            "departure": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-08-29T11:30:00"
+            },
+            "arrival": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-08-29T13:00:00"
+            },
+            "price": 105.00,
+            "people": 2,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "British Airways",
+                "logo": "https://example.com/logos/ba.png"
+            }
+        },
+        {
+            "id": 112,
+            "departure": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-08-29T15:00:00"
+            },
+            "arrival": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-08-29T18:30:00"
+            },
+            "price": 110.00,
+            "people": 2,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "British Airways",
+                "logo": "https://example.com/logos/ba.png"
+            }
+        },
+        {
+            "id": 113,
+            "departure": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-08-30T08:45:00"
+            },
+            "arrival": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-08-30T12:15:00"
+            },
+            "price": 145.00,
+            "people": 1,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "British Airways",
+                "logo": "https://example.com/logos/ba.png"
+            }
+        },
+        {
+            "id": 114,
+            "departure": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-08-30T14:15:00"
+            },
+            "arrival": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-08-30T16:45:00"
+            },
+            "price": 150.00,
+            "people": 1,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Alitalia",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Alitalia_logo_2017.png/1200px-Alitalia_logo_2017.png"
+            }
+        },
+        {
+            "id": 115,
+            "departure": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-08-31T10:30:00"
+            },
+            "arrival": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-08-31T13:00:00"
+            },
+            "price": 95.00,
+            "people": 2,
+            "flightTime": "1h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "KLM",
+                "logo": "https://example.com/logos/klm.png"
+            }
+        },
+        {
+            "id": 116,
+            "departure": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-08-31T15:00:00"
+            },
+            "arrival": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-08-31T15:30:00"
+            },
+            "price": 100.00,
+            "people": 2,
+            "flightTime": "1h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "KLM",
+                "logo": "https://example.com/logos/klm.png"
+            }
+        },
+        {
+            "id": 117,
+            "departure": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-09-01T12:00:00"
+            },
+            "arrival": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-09-01T14:30:00"
+            },
+            "price": 125.00,
+            "people": 1,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "KLM",
+                "logo": "https://example.com/logos/klm.png"
+            }
+        },
+        {
+            "id": 118,
+            "departure": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-09-01T16:30:00"
+            },
+            "arrival": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-09-01T19:00:00"
+            },
+            "price": 130.00,
+            "people": 1,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Alitalia",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Alitalia_logo_2017.png/1200px-Alitalia_logo_2017.png"
+            }
+        },
+        {
+            "id": 119,
+            "departure": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-09-02T07:15:00"
+            },
+            "arrival": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-02T09:30:00"
+            },
+            "price": 135.00,
+            "people": 2,
+            "flightTime": "2h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 120,
+            "departure": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-02T11:30:00"
+            },
+            "arrival": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-09-02T13:45:00"
+            },
+            "price": 140.00,
+            "people": 2,
+            "flightTime": "2h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 121,
+            "departure": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-09-03T13:20:00"
+            },
+            "arrival": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-03T15:30:00"
+            },
+            "price": 155.00,
+            "people": 1,
+            "flightTime": "2h 10m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Czech Airlines",
+                "logo": "https://example.com/logos/czech.png"
+            }
+        },
+        {
+            "id": 122,
+            "departure": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-03T17:30:00"
+            },
+            "arrival": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-09-03T19:40:00"
+            },
+            "price": 160.00,
+            "people": 1,
+            "flightTime": "2h 10m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Czech Airlines",
+                "logo": "https://example.com/logos/czech.png"
+            }
+        },
+        {
+            "id": 123,
+            "departure": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-09-04T16:00:00"
+            },
+            "arrival": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-04T18:30:00"
+            },
+            "price": 165.00,
+            "people": 2,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 124,
+            "departure": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-04T20:30:00"
+            },
+            "arrival": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-09-04T23:00:00"
+            },
+            "price": 170.00,
+            "people": 2,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 125,
+            "departure": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-09-05T08:15:00"
+            },
+            "arrival": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-05T10:45:00"
+            },
+            "price": 175.00,
+            "people": 1,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Czech Airlines",
+                "logo": "https://example.com/logos/czech.png"
+            }
+        },
+        {
+            "id": 126,
+            "departure": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-05T12:45:00"
+            },
+            "arrival": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-09-05T15:15:00"
+            },
+            "price": 180.00,
+            "people": 1,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Czech Airlines",
+                "logo": "https://example.com/logos/czech.png"
+            }
+        },
+        {
+            "id": 127,
+            "departure": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-09-06T11:00:00"
+            },
+            "arrival": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-06T14:30:00"
+            },
+            "price": 185.00,
+            "people": 2,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 128,
+            "departure": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-06T16:30:00"
+            },
+            "arrival": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-09-06T18:00:00"
+            },
+            "price": 190.00,
+            "people": 2,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 129,
+            "departure": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-09-07T09:30:00"
+            },
+            "arrival": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-07T12:45:00"
+            },
+            "price": 195.00,
+            "people": 1,
+            "flightTime": "2h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Czech Airlines",
+                "logo": "https://example.com/logos/czech.png"
+            }
+        },
+        {
+            "id": 130,
+            "departure": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-07T14:45:00"
+            },
+            "arrival": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-09-07T16:00:00"
+            },
+            "price": 200.00,
+            "people": 1,
+            "flightTime": "2h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Czech Airlines",
+                "logo": "https://example.com/logos/czech.png"
+            }
+        },
+        {
+            "id": 131,
+            "departure": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-09-08T14:20:00"
+            },
+            "arrival": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-08T16:00:00"
+            },
+            "price": 155.00,
+            "people": 2,
+            "flightTime": "1h 40m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 132,
+            "departure": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-08T18:00:00"
+            },
+            "arrival": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-09-08T19:40:00"
+            },
+            "price": 160.00,
+            "people": 2,
+            "flightTime": "1h 40m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 133,
+            "departure": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-09-09T10:15:00"
+            },
+            "arrival": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-09T12:30:00"
+            },
+            "price": 165.00,
+            "people": 1,
+            "flightTime": "2h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Czech Airlines",
+                "logo": "https://example.com/logos/czech.png"
+            }
+        },
+        {
+            "id": 134,
+            "departure": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-09T14:30:00"
+            },
+            "arrival": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-09-09T16:45:00"
+            },
+            "price": 170.00,
+            "people": 1,
+            "flightTime": "2h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Czech Airlines",
+                "logo": "https://example.com/logos/czech.png"
+            }
+        },
+        {
+            "id": 135,
+            "departure": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-09-10T12:45:00"
+            },
+            "arrival": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-10T15:00:00"
+            },
+            "price": 145.00,
+            "people": 2,
+            "flightTime": "2h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 136,
+            "departure": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-10T17:00:00"
+            },
+            "arrival": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-09-10T19:15:00"
+            },
+            "price": 150.00,
+            "people": 2,
+            "flightTime": "2h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 137,
+            "departure": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-09-11T08:30:00"
+            },
+            "arrival": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-11T10:30:00"
+            },
+            "price": 135.00,
+            "people": 1,
+            "flightTime": "2h 00m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Czech Airlines",
+                "logo": "https://example.com/logos/czech.png"
+            }
+        },
+        {
+            "id": 138,
+            "departure": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-11T12:30:00"
+            },
+            "arrival": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-09-11T14:30:00"
+            },
+            "price": 140.00,
+            "people": 1,
+            "flightTime": "2h 00m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "KLM",
+                "logo": "https://example.com/logos/klm.png"
+            }
+        },
+        {
+            "id": 139,
+            "departure": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-12T15:45:00"
+            },
+            "arrival": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-12T17:00:00"
+            },
+            "price": 85.00,
+            "people": 2,
+            "flightTime": "1h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Czech Airlines",
+                "logo": "https://example.com/logos/czech.png"
+            }
+        },
+        {
+            "id": 140,
+            "departure": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-12T19:00:00"
+            },
+            "arrival": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-12T20:15:00"
+            },
+            "price": 90.00,
+            "people": 2,
+            "flightTime": "1h 15m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 141,
+            "departure": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-09-13T09:00:00"
+            },
+            "arrival": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-13T13:30:00"
+            },
+            "price": 225.00,
+            "people": 1,
+            "flightTime": "3h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 142,
+            "departure": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-13T15:30:00"
+            },
+            "arrival": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-09-13T18:00:00"
+            },
+            "price": 230.00,
+            "people": 1,
+            "flightTime": "3h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 143,
+            "departure": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-09-14T11:15:00"
+            },
+            "arrival": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-14T20:45:00"
+            },
+            "price": 395.00,
+            "people": 2,
+            "flightTime": "7h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Emirates",
+                "logo": "https://example.com/logos/emirates.png"
+            }
+        },
+        {
+            "id": 144,
+            "departure": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-14T22:45:00"
+            },
+            "arrival": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-09-15T03:15:00"
+            },
+            "price": 405.00,
+            "people": 2,
+            "flightTime": "7h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Emirates",
+                "logo": "https://example.com/logos/emirates.png"
+            }
+        },
+        {
+            "id": 145,
+            "departure": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-09-15T13:30:00"
+            },
+            "arrival": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-15T18:00:00"
+            },
+            "price": 195.00,
+            "people": 1,
+            "flightTime": "3h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 146,
+            "departure": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-15T20:00:00"
+            },
+            "arrival": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-09-15T22:30:00"
+            },
+            "price": 200.00,
+            "people": 1,
+            "flightTime": "3h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 147,
+            "departure": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-09-16T07:45:00"
+            },
+            "arrival": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-16T13:15:00"
+            },
+            "price": 215.00,
+            "people": 2,
+            "flightTime": "4h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 148,
+            "departure": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-16T15:15:00"
+            },
+            "arrival": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-09-16T17:45:00"
+            },
+            "price": 220.00,
+            "people": 2,
+            "flightTime": "4h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 149,
+            "departure": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-09-17T10:30:00"
+            },
+            "arrival": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-17T14:00:00"
+            },
+            "price": 185.00,
+            "people": 1,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 150,
+            "departure": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-17T16:00:00"
+            },
+            "arrival": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-09-17T17:30:00"
+            },
+            "price": 190.00,
+            "people": 1,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 151,
+            "departure": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-09-18T12:15:00"
+            },
+            "arrival": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-18T16:45:00"
+            },
+            "price": 205.00,
+            "people": 2,
+            "flightTime": "3h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 152,
+            "departure": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-18T18:45:00"
+            },
+            "arrival": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-09-18T21:15:00"
+            },
+            "price": 210.00,
+            "people": 2,
+            "flightTime": "3h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 153,
+            "departure": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-19T09:20:00"
+            },
+            "arrival": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-19T12:30:00"
+            },
+            "price": 175.00,
+            "people": 1,
+            "flightTime": "2h 10m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 154,
+            "departure": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-19T14:30:00"
+            },
+            "arrival": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-19T16:40:00"
+            },
+            "price": 180.00,
+            "people": 1,
+            "flightTime": "2h 10m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 155,
+            "departure": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-20T11:45:00"
+            },
+            "arrival": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-20T15:15:00"
+            },
+            "price": 195.00,
+            "people": 2,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 156,
+            "departure": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-20T17:15:00"
+            },
+            "arrival": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-20T19:45:00"
+            },
+            "price": 200.00,
+            "people": 2,
+            "flightTime": "2h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 157,
+            "departure": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-09-21T14:30:00"
+            },
+            "arrival": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-22T01:00:00"
+            },
+            "price": 485.00,
             "people": 1,
             "flightTime": "7h 30m",
             "direct": true,
             "layover": false,
             "airline": {
-                "name": "Qatar Airways",
-                "logo": "https://example.com/logos/qatar.png"
+                "name": "Emirates",
+                "logo": "https://example.com/logos/emirates.png"
+            }
+        },
+        {
+            "id": 158,
+            "departure": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-22T03:00:00"
+            },
+            "arrival": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-09-22T07:30:00"
+            },
+            "price": 495.00,
+            "people": 1,
+            "flightTime": "7h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Emirates",
+                "logo": "https://example.com/logos/emirates.png"
+            }
+        },
+        {
+            "id": 159,
+            "departure": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-09-22T16:45:00"
+            },
+            "arrival": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-23T02:15:00"
+            },
+            "price": 425.00,
+            "people": 2,
+            "flightTime": "7h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Emirates",
+                "logo": "https://example.com/logos/emirates.png"
+            }
+        },
+        {
+            "id": 160,
+            "departure": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-23T04:15:00"
+            },
+            "arrival": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-09-23T08:45:00"
+            },
+            "price": 435.00,
+            "people": 2,
+            "flightTime": "7h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Emirates",
+                "logo": "https://example.com/logos/emirates.png"
+            }
+        },
+        {
+            "id": 161,
+            "departure": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-09-23T18:20:00"
+            },
+            "arrival": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-24T03:50:00"
+            },
+            "price": 445.00,
+            "people": 1,
+            "flightTime": "6h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Emirates",
+                "logo": "https://example.com/logos/emirates.png"
+            }
+        },
+        {
+            "id": 162,
+            "departure": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-24T05:50:00"
+            },
+            "arrival": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-09-24T10:20:00"
+            },
+            "price": 455.00,
+            "people": 1,
+            "flightTime": "6h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Emirates",
+                "logo": "https://example.com/logos/emirates.png"
+            }
+        },
+        {
+            "id": 163,
+            "departure": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-09-24T19:30:00"
+            },
+            "arrival": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-25T06:00:00"
+            },
+            "price": 465.00,
+            "people": 2,
+            "flightTime": "7h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Emirates",
+                "logo": "https://example.com/logos/emirates.png"
+            }
+        },
+        {
+            "id": 164,
+            "departure": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-25T08:00:00"
+            },
+            "arrival": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-09-25T12:30:00"
+            },
+            "price": 475.00,
+            "people": 2,
+            "flightTime": "7h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "KLM",
+                "logo": "https://example.com/logos/klm.png"
+            }
+        },
+        {
+            "id": 165,
+            "departure": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-25T21:15:00"
+            },
+            "arrival": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-26T06:45:00"
+            },
+            "price": 455.00,
+            "people": 1,
+            "flightTime": "6h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Emirates",
+                "logo": "https://example.com/logos/emirates.png"
+            }
+        },
+        {
+            "id": 166,
+            "departure": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-26T08:45:00"
+            },
+            "arrival": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-09-26T13:15:00"
+            },
+            "price": 465.00,
+            "people": 1,
+            "flightTime": "6h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 167,
+            "departure": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-26T17:45:00"
+            },
+            "arrival": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-27T03:15:00"
+            },
+            "price": 485.00,
+            "people": 2,
+            "flightTime": "6h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Emirates",
+                "logo": "https://example.com/logos/emirates.png"
+            }
+        },
+        {
+            "id": 168,
+            "departure": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-27T05:15:00"
+            },
+            "arrival": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-09-27T11:45:00"
+            },
+            "price": 495.00,
+            "people": 2,
+            "flightTime": "6h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Emirates",
+                "logo": "https://example.com/logos/emirates.png"
+            }
+        },
+        {
+            "id": 169,
+            "departure": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-27T20:30:00"
+            },
+            "arrival": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-28T01:00:00"
+            },
+            "price": 285.00,
+            "people": 1,
+            "flightTime": "3h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Emirates",
+                "logo": "https://example.com/logos/emirates.png"
+            }
+        },
+        {
+            "id": 170,
+            "departure": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-09-28T03:00:00"
+            },
+            "arrival": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-09-28T06:30:00"
+            },
+            "price": 295.00,
+            "people": 1,
+            "flightTime": "3h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 171,
+            "departure": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-09-28T10:45:00"
+            },
+            "arrival": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-09-28T13:15:00"
+            },
+            "price": 385.00,
+            "people": 2,
+            "flightTime": "8h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 172,
+            "departure": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-09-28T15:15:00"
+            },
+            "arrival": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-09-29T04:45:00"
+            },
+            "price": 395.00,
+            "people": 2,
+            "flightTime": "8h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 173,
+            "departure": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-09-29T12:30:00"
+            },
+            "arrival": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-09-29T16:00:00"
+            },
+            "price": 415.00,
+            "people": 1,
+            "flightTime": "8h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Iberia",
+                "logo": "https://grupo.iberia.com/contents/archives/475/109/images/thumb255x185_auto/af-iberia-vp-rgb-pos-5b503_thumb.jpg"
+            }
+        },
+        {
+            "id": 174,
+            "departure": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-09-29T18:00:00"
+            },
+            "arrival": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-09-30T07:30:00"
+            },
+            "price": 425.00,
+            "people": 1,
+            "flightTime": "8h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Iberia",
+                "logo": "https://grupo.iberia.com/contents/archives/475/109/images/thumb255x185_auto/af-iberia-vp-rgb-pos-5b503_thumb.jpg"
+            }
+        },
+        {
+            "id": 175,
+            "departure": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-09-30T11:20:00"
+            },
+            "arrival": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-09-30T14:50:00"
+            },
+            "price": 365.00,
+            "people": 2,
+            "flightTime": "8h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "British Airways",
+                "logo": "https://example.com/logos/ba.png"
+            }
+        },
+        {
+            "id": 176,
+            "departure": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-09-30T16:50:00"
+            },
+            "arrival": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-10-01T04:20:00"
+            },
+            "price": 375.00,
+            "people": 2,
+            "flightTime": "8h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "British Airways",
+                "logo": "https://example.com/logos/ba.png"
+            }
+        },
+        {
+            "id": 177,
+            "departure": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-10-01T13:15:00"
+            },
+            "arrival": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-10-01T17:45:00"
+            },
+            "price": 435.00,
+            "people": 1,
+            "flightTime": "9h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Alitalia",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Alitalia_logo_2017.png/1200px-Alitalia_logo_2017.png"
+            }
+        },
+        {
+            "id": 178,
+            "departure": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-10-01T19:45:00"
+            },
+            "arrival": {
+                "code": "FCO",
+                "city": "Roma",
+                "date": "2024-10-02T09:15:00"
+            },
+            "price": 445.00,
+            "people": 1,
+            "flightTime": "9h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Alitalia",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Alitalia_logo_2017.png/1200px-Alitalia_logo_2017.png"
+            }
+        },
+        {
+            "id": 179,
+            "departure": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-10-02T14:30:00"
+            },
+            "arrival": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-10-02T18:00:00"
+            },
+            "price": 385.00,
+            "people": 2,
+            "flightTime": "8h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "KLM",
+                "logo": "https://example.com/logos/klm.png"
+            }
+        },
+        {
+            "id": 180,
+            "departure": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-10-02T20:00:00"
+            },
+            "arrival": {
+                "code": "AMS",
+                "city": "Amsterdã",
+                "date": "2024-10-03T09:30:00"
+            },
+            "price": 395.00,
+            "people": 2,
+            "flightTime": "8h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "KLM",
+                "logo": "https://example.com/logos/klm.png"
+            }
+        },
+        {
+            "id": 181,
+            "departure": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-10-03T16:45:00"
+            },
+            "arrival": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-10-03T21:15:00"
+            },
+            "price": 455.00,
+            "people": 1,
+            "flightTime": "9h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 182,
+            "departure": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-10-03T23:15:00"
+            },
+            "arrival": {
+                "code": "VIE",
+                "city": "Viena",
+                "date": "2024-10-04T13:45:00"
+            },
+            "price": 465.00,
+            "people": 1,
+            "flightTime": "9h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Austrian Airlines",
+                "logo": "https://example.com/logos/austrian.png"
+            }
+        },
+        {
+            "id": 183,
+            "departure": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-10-04T18:20:00"
+            },
+            "arrival": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-10-04T23:50:00"
+            },
+            "price": 485.00,
+            "people": 2,
+            "flightTime": "9h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Czech Airlines",
+                "logo": "https://example.com/logos/czech.png"
+            }
+        },
+        {
+            "id": 184,
+            "departure": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-10-05T01:50:00"
+            },
+            "arrival": {
+                "code": "PRG",
+                "city": "Praga",
+                "date": "2024-10-05T16:20:00"
+            },
+            "price": 495.00,
+            "people": 2,
+            "flightTime": "9h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Czech Airlines",
+                "logo": "https://example.com/logos/czech.png"
+            }
+        },
+        {
+            "id": 185,
+            "departure": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-10-05T19:15:00"
+            },
+            "arrival": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-10-06T02:45:00"
+            },
+            "price": 515.00,
+            "people": 1,
+            "flightTime": "11h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 186,
+            "departure": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-10-06T04:45:00"
+            },
+            "arrival": {
+                "code": "IST",
+                "city": "Istambul",
+                "date": "2024-10-06T20:15:00"
+            },
+            "price": 525.00,
+            "people": 1,
+            "flightTime": "11h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Turkish Airlines",
+                "logo": "https://example.com/logos/turkish.png"
+            }
+        },
+        {
+            "id": 187,
+            "departure": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-10-06T22:30:00"
+            },
+            "arrival": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-10-07T06:00:00"
+            },
+            "price": 685.00,
+            "people": 2,
+            "flightTime": "14h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Emirates",
+                "logo": "https://example.com/logos/emirates.png"
+            }
+        },
+        {
+            "id": 188,
+            "departure": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-10-07T08:00:00"
+            },
+            "arrival": {
+                "code": "DXB",
+                "city": "Dubai",
+                "date": "2024-10-08T03:30:00"
+            },
+            "price": 695.00,
+            "people": 2,
+            "flightTime": "14h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Emirates",
+                "logo": "https://example.com/logos/emirates.png"
+            }
+        },
+        {
+            "id": 189,
+            "departure": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-10-08T11:30:00"
+            },
+            "arrival": {
+                "code": "YYZ",
+                "city": "Toronto",
+                "date": "2024-10-08T14:00:00"
+            },
+            "price": 425.00,
+            "people": 1,
+            "flightTime": "8h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air Canada",
+                "logo": "https://example.com/logos/aircanada.png"
+            }
+        },
+        {
+            "id": 190,
+            "departure": {
+                "code": "YYZ",
+                "city": "Toronto",
+                "date": "2024-10-08T16:00:00"
+            },
+            "arrival": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-10-09T05:30:00"
+            },
+            "price": 435.00,
+            "people": 1,
+            "flightTime": "8h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 191,
+            "departure": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-10-09T13:45:00"
+            },
+            "arrival": {
+                "code": "YYZ",
+                "city": "Toronto",
+                "date": "2024-10-09T16:15:00"
+            },
+            "price": 395.00,
+            "people": 2,
+            "flightTime": "8h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air Canada",
+                "logo": "https://example.com/logos/aircanada.png"
+            }
+        },
+        {
+            "id": 192,
+            "departure": {
+                "code": "YYZ",
+                "city": "Toronto",
+                "date": "2024-10-09T18:15:00"
+            },
+            "arrival": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-10-10T05:45:00"
+            },
+            "price": 405.00,
+            "people": 2,
+            "flightTime": "8h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "British Airways",
+                "logo": "https://example.com/logos/ba.png"
+            }
+        },
+        {
+            "id": 193,
+            "departure": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-10-10T10:20:00"
+            },
+            "arrival": {
+                "code": "YYZ",
+                "city": "Toronto",
+                "date": "2024-10-10T12:00:00"
+            },
+            "price": 185.00,
+            "people": 1,
+            "flightTime": "1h 40m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air Canada",
+                "logo": "https://example.com/logos/aircanada.png"
+            }
+        },
+        {
+            "id": 194,
+            "departure": {
+                "code": "YYZ",
+                "city": "Toronto",
+                "date": "2024-10-10T14:00:00"
+            },
+            "arrival": {
+                "code": "JFK",
+                "city": "Nova Iorque",
+                "date": "2024-10-10T15:40:00"
+            },
+            "price": 195.00,
+            "people": 1,
+            "flightTime": "1h 40m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air Canada",
+                "logo": "https://example.com/logos/aircanada.png"
+            }
+        },
+        {
+            "id": 195,
+            "departure": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-10-11T09:00:00"
+            },
+            "arrival": {
+                "code": "HND",
+                "city": "Tóquio",
+                "date": "2024-10-12T05:30:00"
+            },
+            "price": 685.00,
+            "people": 2,
+            "flightTime": "12h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Japan Airlines",
+                "logo": "https://example.com/logos/jal.png"
+            }
+        },
+        {
+            "id": 196,
+            "departure": {
+                "code": "HND",
+                "city": "Tóquio",
+                "date": "2024-10-12T07:30:00"
+            },
+            "arrival": {
+                "code": "CDG",
+                "city": "Paris",
+                "date": "2024-10-12T13:00:00"
+            },
+            "price": 695.00,
+            "people": 2,
+            "flightTime": "12h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Air France",
+                "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Air_France_Logo.svg/2560px-Air_France_Logo.svg.png"
+            }
+        },
+        {
+            "id": 197,
+            "departure": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-10-12T22:15:00"
+            },
+            "arrival": {
+                "code": "HND",
+                "city": "Tóquio",
+                "date": "2024-10-13T18:45:00"
+            },
+            "price": 715.00,
+            "people": 1,
+            "flightTime": "12h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "British Airways",
+                "logo": "https://example.com/logos/ba.png"
+            }
+        },
+        {
+            "id": 198,
+            "departure": {
+                "code": "HND",
+                "city": "Tóquio",
+                "date": "2024-10-13T20:45:00"
+            },
+            "arrival": {
+                "code": "LHR",
+                "city": "Londres",
+                "date": "2024-10-14T02:15:00"
+            },
+            "price": 725.00,
+            "people": 1,
+            "flightTime": "12h 30m",
+            "direct": true,
+            "layover": false,
+            "airline": {
+                "name": "Japan Airlines",
+                "logo": "https://example.com/logos/jal.png"
+            }
+        },
+        {
+            "id": 199,
+            "departure": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-10-14T11:30:00"
+            },
+            "arrival": {
+                "code": "HND",
+                "city": "Tóquio",
+                "date": "2024-10-15T08:00:00"
+            },
+            "price": 735.00,
+            "people": 2,
+            "flightTime": "14h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Japan Airlines",
+                "logo": "https://example.com/logos/jal.png"
+            }
+        },
+        {
+            "id": 200,
+            "departure": {
+                "code": "HND",
+                "city": "Tóquio",
+                "date": "2024-10-15T10:00:00"
+            },
+            "arrival": {
+                "code": "BCN",
+                "city": "Barcelona",
+                "date": "2024-10-15T18:30:00"
+            },
+            "price": 745.00,
+            "people": 2,
+            "flightTime": "14h 30m",
+            "direct": false,
+            "layover": true,
+            "airline": {
+                "name": "Iberia",
+                "logo": "https://grupo.iberia.com/contents/archives/475/109/images/thumb255x185_auto/af-iberia-vp-rgb-pos-5b503_thumb.jpg"
             }
         }
     ]

--- a/js/data/type.json
+++ b/js/data/type.json
@@ -2,63 +2,53 @@
     "types": [
         {
             "id": 1,
-            "Nome": "Turismo Cultural",
-            "Descrição": "Exploração de património histórico, museus, monumentos e tradições locais."
+            "Nome": "Cultural",
+            "Descrição": "Visita a museus, monumentos históricos, sítios arqueológicos e eventos culturais."
         },
         {
             "id": 2,
-            "Nome": "Turismo de Natureza",
-            "Descrição": "Atividades em ambientes naturais como trilhos, parques naturais e observação de fauna e flora."
+            "Nome": "Aventura",
+            "Descrição": "Atividades ao ar livre como montanhismo, rafting, trekking e desportos radicais."
         },
         {
             "id": 3,
-            "Nome": "Turismo Gastronómico",
-            "Descrição": "Descoberta de sabores regionais, restaurantes típicos e festivais de comida."
+            "Nome": "Gastronómico",
+            "Descrição": "Experiências culinárias, visitas a vinícolas, mercados locais e restaurantes típicos."
         },
         {
             "id": 4,
-            "Nome": "Turismo de Aventura",
-            "Descrição": "Prática de desportos radicais, escalada, rafting e atividades ao ar livre."
+            "Nome": "Histórico",
+            "Descrição": "Visita a locais com relevância histórica, castelos, palácios e sítios antigos."
         },
         {
             "id": 5,
-            "Nome": "Turismo Religioso",
+            "Nome": "Religioso",
             "Descrição": "Visita a locais sagrados, peregrinações e eventos religiosos."
         },
         {
             "id": 6,
-            "Nome": "Turismo de Sol e Praia",
+            "Nome": "Balnear",
             "Descrição": "Férias em destinos costeiros, praias e atividades aquáticas."
         },
         {
             "id": 7,
-            "Nome": "Turismo de Saúde e Bem-Estar",
-            "Descrição": "Viagens para spas, termas, clínicas de reabilitação e retiros de bem-estar."
-        },
-        {
-            "id": 8,
-            "Nome": "Turismo Rural",
+            "Nome": "Rural",
             "Descrição": "Experiência em ambientes rurais, quintas, aldeias e contacto com a vida agrícola."
         },
         {
+            "id": 8,
+            "Nome": "Urbano",
+            "Descrição": "Exploração de grandes cidades, vida noturna, shopping e arquitetura moderna."
+        },
+        {
             "id": 9,
-            "Nome": "Turismo de Negócios",
-            "Descrição": "Participação em conferências, feiras, reuniões e eventos corporativos."
+            "Nome": "Luxo",
+            "Descrição": "Experiências premium com acomodações de alto padrão e serviços exclusivos."
         },
         {
             "id": 10,
-            "Nome": "Turismo Desportivo",
-            "Descrição": "Viagens para assistir ou participar em eventos desportivos."
-        },
-        {
-            "id": 11,
-            "Nome": "Turismo de Compras",
-            "Descrição": "Visitas a centros comerciais, mercados e zonas comerciais famosas."
-        },
-        {
-            "id": 12,
-            "Nome": "Turismo Científico",
-            "Descrição": "Participação em congressos, visitas a centros de investigação e museus de ciência."
+            "Nome": "Exótico",
+            "Descrição": "Destinos únicos e diferentes, com culturas e paisagens exóticas."
         }
     ]
 }

--- a/js/models/destinations.js
+++ b/js/models/destinations.js
@@ -88,10 +88,16 @@ export function getDestinationsByTourismType(tourismType) {
         return getAllDestinations();
     }
     
-    return destinations.filter(dest => 
-        dest.TipoTurismo && 
-        dest.TipoTurismo.toLowerCase() === tourismType.toLowerCase()
-    );
+    const normalizedQuizResult = tourismType.trim().toLowerCase();
+
+    return destinations.filter(dest => {
+        if (!dest.TipoTurismo) {
+            return false;
+        }
+        const normalizedDestType = dest.TipoTurismo.trim().toLowerCase();
+        // Verifica se o tipo de turismo do destino inclui o resultado do quiz
+        return normalizedDestType.includes(normalizedQuizResult);
+    });
 }
 
 

--- a/js/models/destinations.js
+++ b/js/models/destinations.js
@@ -88,16 +88,10 @@ export function getDestinationsByTourismType(tourismType) {
         return getAllDestinations();
     }
     
-    const normalizedQuizResult = tourismType.trim().toLowerCase();
-
-    return destinations.filter(dest => {
-        if (!dest.TipoTurismo) {
-            return false;
-        }
-        const normalizedDestType = dest.TipoTurismo.trim().toLowerCase();
-        // Verifica se o tipo de turismo do destino inclui o resultado do quiz
-        return normalizedDestType.includes(normalizedQuizResult);
-    });
+    return destinations.filter(dest => 
+        dest.TipoTurismo && 
+        dest.TipoTurismo.toLowerCase() === tourismType.toLowerCase()
+    );
 }
 
 

--- a/js/models/quiz.js
+++ b/js/models/quiz.js
@@ -1,3 +1,5 @@
+import { renderRecommendedDestinations } from '../views/QuizView.js';
+
 class Quiz {
     constructor() {
         this.currentQuestion = 0;
@@ -134,6 +136,8 @@ class Quiz {
                     </div>
                 </div>
             `).join('');
+        
+        renderRecommendedDestinations(this.finalScores);
     }
 
     setupEventListeners() {

--- a/js/models/quiz.js
+++ b/js/models/quiz.js
@@ -118,12 +118,29 @@ class Quiz {
             this.currentQuestion === this.questions.length - 1 ? 'Ver Resultados' : 'Próximo';
     }
 
-    mostrarResultados() {
+    async mostrarResultados() {
         document.getElementById('quiz-container').classList.add('d-none');
         document.getElementById('results-container').classList.remove('d-none');
         
         const sortedScores = Object.entries(this.finalScores)
             .sort((a, b) => b[1] - a[1]);
+
+        // Guardar os resultados se o utilizador estiver logado
+        const loggedUser = JSON.parse(sessionStorage.getItem('loggedUser'));
+        if (loggedUser) {
+            try {
+                const users = JSON.parse(localStorage.getItem('users')) || [];
+                const userIndex = users.findIndex(u => u.id === loggedUser.id);
+                if (userIndex !== -1) {
+                    users[userIndex].quizScores = this.finalScores;
+                    loggedUser.quizScores = this.finalScores;
+                    localStorage.setItem('users', JSON.stringify(users));
+                    sessionStorage.setItem('loggedUser', JSON.stringify(loggedUser));
+                }
+            } catch (error) {
+                console.error("Erro ao guardar os resultados do quiz:", error);
+            }
+        }
 
         document.getElementById('scores-container').innerHTML = sortedScores
             .map(([type, score]) => `

--- a/js/views/AdmniDestinations.js
+++ b/js/views/AdmniDestinations.js
@@ -91,8 +91,37 @@ async function renderDestinations(page = 1, destinationsList = null) {
     }
 }
 
+// Popula o modal de adicionar com tipos dinâmicos
+async function populateAddModal() {
+    await loadTypes();
+    const types = getAllTypes();
+    const select = document.querySelector('#addDestinationModal select[name="TipoTurismo"]');
+    if (select) {
+        select.innerHTML = '<option value="">Selecione o tipo</option>';
+        types.forEach(type => {
+            select.innerHTML += `<option value="${type.Nome}">${type.Nome}</option>`;
+        });
+    }
+}
+
+// Popula o modal de editar com tipos dinâmicos
+async function populateEditModal() {
+    await loadTypes();
+    const types = getAllTypes();
+    const select = document.querySelector('#editDestinationModal select[name="editTipoTurismo"]');
+    if (select) {
+        select.innerHTML = '<option value="">Selecione o tipo</option>';
+        types.forEach(type => {
+            select.innerHTML += `<option value="${type.Nome}">${type.Nome}</option>`;
+        });
+    }
+}
+
 // Adicionar novo destino
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
+    await populateAddModal();
+    await populateEditModal();
+    
     const addForm = document.getElementById('addDestinationForm');
 
     addForm.addEventListener('submit', async (event) => {
@@ -162,6 +191,8 @@ document.getElementById('destinationsTable').addEventListener('click', async (ev
             alert('Destino não encontrado!');
             return;
         }
+
+        await populateEditModal();
 
         document.querySelector('[name="editDestinationId"]').value = destination.id;
         document.querySelector('[name="editCodigoDestino"]').value = destination.CodigoDestino;

--- a/js/views/ProfileView.js
+++ b/js/views/ProfileView.js
@@ -1,4 +1,6 @@
 import { loadUsers, updateUser } from '../models/users.js';
+import { getDestinationsByTourismType, loadDestinations } from '../models/destinations.js';
+import { loadFlights } from '../models/flights.js';
 
 document.addEventListener('DOMContentLoaded', function() {
     const loggedUser = JSON.parse(sessionStorage.getItem('loggedUser'));
@@ -13,15 +15,16 @@ document.addEventListener('DOMContentLoaded', function() {
     const profileImage = document.getElementById('profileImage');
     const userNameDisplay = document.getElementById('userNameDisplay');
 
-    nameInput.value = loggedUser.name;
-    emailInput.value = loggedUser.email;
-
-    if (userNameDisplay && loggedUser.name) {
+    if (loggedUser) {
+        nameInput.value = loggedUser.name;
+        emailInput.value = loggedUser.email;
+        profileImage.src = loggedUser.profImg || '../img/default_Avatar.jpg';
         userNameDisplay.textContent = `Olá, ${loggedUser.name}!`;
-    }
 
-    if (loggedUser.profImg) {
-        profileImage.src = loggedUser.profImg;
+        // Exibir resultados do quiz se existirem
+        if (loggedUser.quizScores) {
+            displayQuizResults(loggedUser.quizScores);
+        }
     }
 
 
@@ -36,6 +39,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 sessionStorage.setItem('loggedUser', JSON.stringify(loggedUser));
             }
             reader.readAsDataURL(file);
+            showMessage(error.message, 'danger');
         }
     });
 
@@ -65,7 +69,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 emailInput.value,
                 newPassword || loggedUser.password,
                 profileImage.src,
-                loggedUser.favourits
+                loggedUser.favourits,
+                loggedUser.quizScores
             );
 
             // Update session storage and display name
@@ -89,6 +94,129 @@ document.addEventListener('DOMContentLoaded', function() {
         window.location.href = '../index.html';
     });
 });
+
+async function displayQuizResults(scores) {
+    const quizSection = document.getElementById('quiz-results-section');
+    const scoresContainer = document.getElementById('scores-container');
+    if (!quizSection || !scoresContainer) return;
+
+    quizSection.style.display = 'block';
+
+    const sortedScores = Object.entries(scores)
+        .sort((a, b) => b[1] - a[1])
+        .filter(([, score]) => score > 0);
+
+    scoresContainer.innerHTML = sortedScores.map(([type, score]) => `
+        <div class="col-md-4 col-sm-6 mb-3">
+            <div class="card h-100 text-center border-danger">
+                <div class="card-body d-flex flex-column justify-content-center">
+                    <h5 class="card-title">${type}</h5>
+                    <p class="display-4 text-danger mb-0">${score}</p>
+                </div>
+            </div>
+        </div>
+    `).join('');
+
+    await renderProfileRecommendations(scores);
+}
+
+async function renderProfileRecommendations(scores) {
+    const recommendedContainer = document.getElementById('recommended-destinations-container');
+    if (!recommendedContainer) return;
+
+    const getTopTourismType = (s) => Object.keys(s).reduce((a, b) => s[a] > s[b] ? a : b);
+    const topType = getTopTourismType(scores);
+
+    try {
+        await loadDestinations();
+        const allFlightsData = await loadFlights();
+        const destinations = await getDestinationsByTourismType(topType);
+
+        if (!destinations || destinations.length === 0) {
+            recommendedContainer.innerHTML = `<p class="text-center">Não encontrámos recomendações para o seu perfil.</p>`;
+            return;
+        }
+
+        const destinationsWithFlights = destinations.map(dest => {
+            const flightsToDest = allFlightsData.filter(f => f.arrival?.code === dest.CodigoDestino && f.price);
+            const cheapestFlight = flightsToDest.length > 0 ? flightsToDest.reduce((min, f) => f.price < min.price ? f : min) : null;
+            return { ...dest, cheapestFlight };
+        });
+
+        const destinationCards = destinationsWithFlights.map(dest => {
+            const flightId = dest.cheapestFlight ? dest.cheapestFlight.id : null;
+            return `
+            <div class="destination-card" data-flight-id="${flightId || ''}">
+                <div class="card h-100">
+                    ${flightId ? `<button class="favorite-btn"><i class="fas fa-star"></i></button>` : ''}
+                    <img src="${dest.ImagemDestino || '../img/homeBg.jpg'}" class="card-img-top" alt="${dest.Destino}">
+                    <div class="card-body d-flex flex-column">
+                        <h5 class="card-title">${dest.Destino}</h5>
+                        <p class="card-text text-muted small flex-grow-1">${dest.Descricao ? dest.Descricao.substring(0, 80) + '...' : 'Sem descrição.'}</p>
+                        <button class="btn btn-primary mt-auto btn-ver-ofertas" data-destination='${JSON.stringify(dest).replace(/'/g, "&apos;")}'>Ver Ofertas</button>
+                    </div>
+                </div>
+            </div>`;
+        }).join('');
+
+        recommendedContainer.innerHTML = `<div class="recommended-destinations-list">${destinationCards}</div>`;
+        addRecommendationEventListeners(recommendedContainer, allFlightsData);
+    } catch (error) {
+        console.error('Erro ao renderizar recomendações no perfil:', error);
+        recommendedContainer.innerHTML = '<p class="text-center">Ocorreu um erro ao carregar as recomendações.</p>';
+    }
+}
+
+function addRecommendationEventListeners(container, allFlightsData) {
+    container.addEventListener('click', async (e) => {
+        const verOfertasBtn = e.target.closest('.btn-ver-ofertas');
+        if (verOfertasBtn) {
+            const dest = JSON.parse(verOfertasBtn.dataset.destination.replace(/&apos;/g, "'"));
+            sessionStorage.setItem('searchInfo', JSON.stringify({
+                origemNome: "Porto",
+                destinoNome: dest.Destino,
+                dataIda: null, dataChegada: null, passageiros: 1, tipoTurismo: dest.TipoTurismo
+            }));
+            window.location.href = "../html/flight.html";
+            return;
+        }
+
+        const favBtn = e.target.closest('.favorite-btn');
+        if (favBtn) {
+            const card = favBtn.closest('.destination-card');
+            const flightId = card.dataset.flightId;
+            if (!flightId) return;
+
+            const user = JSON.parse(sessionStorage.getItem('loggedUser'));
+            if (!user) {
+                alert('Faça login para adicionar aos favoritos.');
+                window.location.href = './login.html';
+                return;
+            }
+
+            const flight = allFlightsData.find(f => f.id == flightId);
+            if (!flight) return;
+
+            const users = JSON.parse(localStorage.getItem('users')) || [];
+            const userIndex = users.findIndex(u => u.id === user.id);
+            if (userIndex === -1) return;
+
+            const userObj = users[userIndex];
+            if (!Array.isArray(userObj.favourits)) userObj.favourits = [];
+
+            if (userObj.favourits.some(fav => fav.id == flight.id)) {
+                alert('Este voo já está nos seus favoritos.');
+                return;
+            }
+
+            userObj.favourits.push(flight);
+            localStorage.setItem('users', JSON.stringify(users));
+            sessionStorage.setItem('loggedUser', JSON.stringify(userObj));
+            alert('Voo adicionado aos favoritos!');
+            favBtn.classList.add('active');
+        }
+    });
+}
 
 function showMessage(message, type) {
     const messageDiv = document.getElementById('message');

--- a/js/views/QuizView.js
+++ b/js/views/QuizView.js
@@ -41,7 +41,7 @@ export async function renderRecommendedDestinations(scores) {
                     <div class="card-body d-flex flex-column">
                         <h5 class="card-title">${dest.Destino}</h5>
                         <p class="card-text text-muted small flex-grow-1">${dest.Descricao ? dest.Descricao.substring(0, 80) + '...' : 'Sem descrição disponível.'}</p>
-                        <a href="./flight.html?destination=${dest.CodigoDestino}" class="btn btn-primary mt-auto">Ver Ofertas</a>
+                        <button class="btn btn-primary mt-auto" onclick='setFlightSearchFromQuiz(${JSON.stringify(dest).replace(/'/g, "&apos;")})'>Ver Ofertas</button>
                     </div>
                 </div>
             </div>
@@ -58,4 +58,44 @@ export async function renderRecommendedDestinations(scores) {
         console.error('Erro ao renderizar destinos recomendados:', error);
         recommendedContainer.innerHTML = '<p class="text-center">Ocorreu um erro ao carregar as recomendações.</p>';
     }
+}
+
+window.setFlightSearchFromQuiz = function(dest) {
+    const today = new Date();
+    const dataIda = today.toISOString().split('T')[0];
+    const dataChegada = new Date(today.getTime() + 2 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+
+    // Procura o destino "Porto" no array de destinos para obter o ID correto
+    fetch('/js/data/destinations.json')
+        .then(response => response.json())
+        .then(data => {
+            const destinos = data.destenys;
+            const portoDestino = destinos.find(d => d.Destino === "Porto" || d.CodigoDestino === "OPO");
+            const destinoSelecionado = destinos.find(d => d.id === dest.id);
+            
+            sessionStorage.setItem('searchInfo', JSON.stringify({
+                origemNome: portoDestino ? portoDestino.Destino : "Porto",
+                destinoNome: dest.Destino,
+                dataIda,
+                dataChegada,
+                passageiros: 2,
+                tipoTurismo: dest.TipoTurismo
+            }));
+            
+            window.location.href = "../html/flight.html";
+        })
+        .catch(error => {
+            console.error('Erro ao carregar destinos:', error);
+            // Fallback sem verificação
+            sessionStorage.setItem('searchInfo', JSON.stringify({
+                origemNome: "Porto",
+                destinoNome: dest.Destino,
+                dataIda,
+                dataChegada,
+                passageiros: 2,
+                tipoTurismo: dest.TipoTurismo
+            }));
+            
+            window.location.href = "../html/flight.html";
+        });
 }

--- a/js/views/QuizView.js
+++ b/js/views/QuizView.js
@@ -1,0 +1,61 @@
+import { getDestinationsByTourismType, loadDestinations } from '../models/destinations.js';
+
+function getTopTourismType(scores) {
+    if (!scores || Object.keys(scores).length === 0) {
+        return null;
+    }
+    // Ordena os resultados para encontrar o tipo com a maior pontuação
+    const sortedScores = Object.entries(scores).sort((a, b) => b[1] - a[1]);
+    return sortedScores[0][0];
+}
+
+export async function renderRecommendedDestinations(scores) {
+    const recommendedContainer = document.getElementById('recommended-destinations-container');
+    if (!recommendedContainer) {
+        console.error('Container para destinos recomendados não encontrado.');
+        return;
+    }
+
+    const topType = getTopTourismType(scores);
+    if (!topType) {
+        recommendedContainer.innerHTML = '<p class="text-center">Não foi possível determinar o seu perfil de viajante.</p>';
+        return;
+    }
+
+    try {
+        await loadDestinations();
+        const destinations = await getDestinationsByTourismType(topType);
+
+        if (!destinations || destinations.length === 0) {
+            recommendedContainer.innerHTML = `
+                <h2 class="text-center mb-4">Destinos Recomendados para Si</h2>
+                <p class="text-center">De momento, não temos destinos que correspondam ao seu perfil de <strong>${topType}</strong>.</p>
+            `;
+            return;
+        }
+
+        const destinationCards = destinations.map(dest => `
+            <div class="destination-card">
+                <div class="card h-100">
+                    <img src="${dest.ImagemDestino ? `../img/destinations/${dest.ImagemDestino}` : '../img/default_destination.jpg'}" class="card-img-top" alt="${dest.Destino}">
+                    <div class="card-body d-flex flex-column">
+                        <h5 class="card-title">${dest.Destino}</h5>
+                        <p class="card-text text-muted small flex-grow-1">${dest.Descricao ? dest.Descricao.substring(0, 80) + '...' : 'Sem descrição disponível.'}</p>
+                        <a href="./flight.html?destination=${dest.CodigoDestino}" class="btn btn-primary mt-auto">Ver Ofertas</a>
+                    </div>
+                </div>
+            </div>
+        `).join('');
+
+        recommendedContainer.innerHTML = `
+            <h2 class="text-center mb-4">Destinos Recomendados para Si</h2>
+            <div class="recommended-destinations-list">
+                ${destinationCards}
+            </div>
+        `;
+
+    } catch (error) {
+        console.error('Erro ao renderizar destinos recomendados:', error);
+        recommendedContainer.innerHTML = '<p class="text-center">Ocorreu um erro ao carregar as recomendações.</p>';
+    }
+}


### PR DESCRIPTION
- Atualizados os dados nos JSONs de voos com alguns logos corretos das companhias aéreas e nomes de cidades, correção na coerencia entre destinos e tipo de turismo, coerência entre os destinos e voos.
- No painel de admin, deixei dinâmico os filtros por tipo de turismo no painel dos destinos.
  
- Melhorada a exibição dos resultados do quiz, que agora são guardados permanentemente no perfil dos utilizadores autenticados.

- Adicionada funcionalidade à página de perfil para exibir os resultados do quiz e um carrossel de destinos recomendados com base nessas pontuações.

- A vista de favoritos foi otimizada para carregar as imagens corretas dos destinos.
- Implementada a lógica para adicionar/remover voos dos favoritos diretamente a partir dos resultados do quiz e das recomendações no perfil.

- Secção "Ofertas de Voos" do index agora filtra os cards dinamicamente com base num filtro de preço e tem os botões de comprar a funcionar (dá redirect para o flights.html e passa os dados do card)